### PR TITLE
AssemblyScanner now loads all referenced assemblies.

### DIFF
--- a/Code/Core/Revenj.Utility/Reflection/AssemblyScanner.cs
+++ b/Code/Core/Revenj.Utility/Reflection/AssemblyScanner.cs
@@ -6,26 +6,36 @@ using System.Reflection;
 namespace Revenj.Utility
 {
 	/// <summary>
-	/// Utility for scanning assemblies in current AppDomain.
-	/// Microsoft specific assemblies will be skipped.
+	/// Utility for scanning and loading assemblies in current AppDomain.
+	/// Microsoft-specific assemblies will be skipped.
 	/// </summary>
 	public static class AssemblyScanner
 	{
-		private static List<Type> AllTypes = new List<Type>();
 		/// <summary>
-		/// Get assemblies from current AppDomain.
-		/// Don't return dynamic or Microsoft specific assemblies.
+		/// Cache for <see cref="GetAllAssemblies"/>
 		/// </summary>
-		/// <returns>found assemblies</returns>
-		public static IEnumerable<Assembly> GetAssemblies()
+		private static List<Assembly> AllAssemblies = null;
+
+		/// <summary>
+		/// Cache for <see cref="GetAllTypes"/>
+		/// </summary>
+		private static List<Type> AllTypes = null;
+
+		/// <summary>
+		/// Gets currently loaded assemblies from current AppDomain, excluding dynamic or Microsoft specific
+		/// assemblies.
+		/// </summary>
+		/// <returns>Currently loaded assemblies.</returns>
+		public static IEnumerable<Assembly> GetLoadedAssemblies()
 		{
 			return
 				from asm in AppDomain.CurrentDomain.GetAssemblies()
 				where !asm.IsDynamic
 					&& !asm.FullName.StartsWith("Microsoft.")
-					&& !asm.FullName.StartsWith("mscorelib.")
+					&& !asm.FullName.StartsWith("mscorelib")
 				select asm;
 		}
+
 		/// <summary>
 		/// Get all types from assemblies.
 		/// Types will be cached after first call.
@@ -33,22 +43,66 @@ namespace Revenj.Utility
 		/// <returns>Types in assemblies</returns>
 		public static IEnumerable<Type> GetAllTypes()
 		{
-			if (AllTypes.Count > 0)
-				return AllTypes;
-			try
+			if (AllTypes != null)
 			{
-				foreach (var asm in GetAssemblies())
-					foreach (var type in asm.GetTypes().Where(it => it.IsClass || it.IsInterface))
-						AllTypes.Add(type);
-
 				return AllTypes;
 			}
-			catch (ReflectionTypeLoadException ex)
+			else
 			{
-				var first = (ex.LoaderExceptions ?? new Exception[0]).Take(5).ToList();
-				throw new ApplicationException(string.Format(@"Can't load types: 
-{0}
-", string.Join(Environment.NewLine, first.Select(it => it.Message))), ex);
+				try
+				{
+					AllTypes = new List<Type>();
+					foreach (var assembly in GetAllAssemblies())
+					{
+						foreach (var type in assembly.GetTypes().Where(it => it.IsClass || it.IsInterface))
+						{
+							AllTypes.Add(type);
+						}
+					}
+					return AllTypes;
+				}
+				catch (ReflectionTypeLoadException ex)
+				{
+					AllTypes = null;
+					var first = (ex.LoaderExceptions ?? new Exception[0]).Take(5).ToList();
+					throw new ApplicationException(string.Format("Can't load types:{0}{1}", Environment.NewLine, string.Join(Environment.NewLine, first.Select(it => it.Message))), ex);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets all referenced assemblies from current AppDomain, excluding dynamic or Microsoft-specific assemblies.
+		/// Assemblies will be cached after first call.
+		/// </summary>
+		/// <returns>All referenced assemblies.</returns>
+		public static IEnumerable<Assembly> GetAllAssemblies()
+		{
+			if (AllAssemblies != null)
+			{
+				return AllAssemblies;
+			}
+			else
+			{
+				var loadedAssemblies = GetLoadedAssemblies();
+				foreach (var assembly in loadedAssemblies)
+				{
+					LoadReferencedAssembiles(assembly);
+				}
+				AllAssemblies = GetLoadedAssemblies().ToList();
+				return AllAssemblies;
+			}
+		}
+
+		/// <summary>
+		/// Loads all assemblies referenced by the specified assembly.
+		/// </summary>
+		/// <param name="assembly">Assembly whose references to load.</param>
+		public static void LoadReferencedAssembiles(Assembly assembly)
+		{
+			var references = assembly.GetReferencedAssemblies();
+			foreach (var reference in references)
+			{
+				Assembly.Load(reference);
 			}
 		}
 	}

--- a/Code/Core/Revenj.Utility/Reflection/AssemblyScanner.cs
+++ b/Code/Core/Revenj.Utility/Reflection/AssemblyScanner.cs
@@ -47,26 +47,24 @@ namespace Revenj.Utility
 			{
 				return AllTypes;
 			}
-			else
+
+			try
 			{
-				try
+				AllTypes = new List<Type>();
+				foreach (var assembly in GetAllAssemblies())
 				{
-					AllTypes = new List<Type>();
-					foreach (var assembly in GetAllAssemblies())
+					foreach (var type in assembly.GetTypes().Where(it => it.IsClass || it.IsInterface))
 					{
-						foreach (var type in assembly.GetTypes().Where(it => it.IsClass || it.IsInterface))
-						{
-							AllTypes.Add(type);
-						}
+						AllTypes.Add(type);
 					}
-					return AllTypes;
 				}
-				catch (ReflectionTypeLoadException ex)
-				{
-					AllTypes = null;
-					var first = (ex.LoaderExceptions ?? new Exception[0]).Take(5).ToList();
-					throw new ApplicationException(string.Format("Can't load types:{0}{1}", Environment.NewLine, string.Join(Environment.NewLine, first.Select(it => it.Message))), ex);
-				}
+				return AllTypes;
+			}
+			catch (ReflectionTypeLoadException ex)
+			{
+				AllTypes = null;
+				var first = (ex.LoaderExceptions ?? new Exception[0]).Take(5).ToList();
+				throw new ApplicationException(string.Format("Can't load types:{0}{1}", Environment.NewLine, string.Join(Environment.NewLine, first.Select(it => it.Message))), ex);
 			}
 		}
 
@@ -81,16 +79,14 @@ namespace Revenj.Utility
 			{
 				return AllAssemblies;
 			}
-			else
+
+			var loadedAssemblies = GetLoadedAssemblies();
+			foreach (var assembly in loadedAssemblies)
 			{
-				var loadedAssemblies = GetLoadedAssemblies();
-				foreach (var assembly in loadedAssemblies)
-				{
-					LoadReferencedAssembiles(assembly);
-				}
-				AllAssemblies = GetLoadedAssemblies().ToList();
-				return AllAssemblies;
+				LoadReferencedAssembiles(assembly);
 			}
+			AllAssemblies = GetLoadedAssemblies().ToList();
+			return AllAssemblies;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Changed cache variables (`AllAssemblies` and `AllTypes`) to be `null` when uninitialized.
Renamed `GetAssemblies` to `GetLoadedAssemblies`.
Fixed typo in `GetLoadedAssemblies` (*mscorelib* does not have a dot)
Added methods for assembly loading (`GetAllAssemblies` and `LoadReferencedAssembiles`)
Various comment and style changes.

**Not properly tested!**