### PR TITLE
Divisor in NumberConverter can quickly outgrow int32:

### DIFF
--- a/csharp/Core/Revenj.Serialization/Json/Converters/NumberConverter.cs
+++ b/csharp/Core/Revenj.Serialization/Json/Converters/NumberConverter.cs
@@ -618,7 +618,7 @@ namespace Revenj.Serialization.Json.Converters
 			if (ch == '.')
 			{
 				i++;
-				int div = 1;
+				long div = 1;
 				for (; i < buf.Length && i < len; i++)
 				{
 					int ind = buf[i] - 48;
@@ -751,7 +751,7 @@ namespace Revenj.Serialization.Json.Converters
 			if (ch == '.')
 			{
 				i++;
-				int div = 1;
+				long div = 1;
 				for (; i < buf.Length && i < len; i++)
 				{
 					int ind = buf[i] - 48;


### PR DESCRIPTION
This happens when deserializing any double with many decimals "1.0000000001".
This also happens when deserializing a float (e.g. when converting a Location from Point2D.Double (Java client side) to PointF (C# server side).