### PR TITLE
Suport Scala 2.12.x build, add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: scala
+
+branches:
+  only:
+    - travis
+
+jdk:
+  - oraclejdk8
+
+sudo: false
+
+notifications:
+  email:
+    recipients:
+      - marko.elezovic@oradian.com
+
+before_script: cd scala
+
+script:
+  - sbt +publishLocal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,30 @@
-language: scala
-
 branches:
   only:
-    - travis
+    - master
+
+language: scala
+
+sudo: required
+
+before_install:
+  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' > /etc/apt/sources.list.d/mono-xamarin.list"
+  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list"
+  - sudo apt-get -qq update
+  - sudo apt-get install --force-yes mono-devel
 
 jdk:
   - oraclejdk8
 
-sudo: false
+scala:
+  - 2.11.8
+  - 2.12.1
+
+before_script: cd scala
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION publishLocal test
 
 notifications:
   email:
     recipients:
       - marko.elezovic@oradian.com
-
-before_script: cd scala
-
-script:
-  - sbt +publishLocal

--- a/scala/README.md
+++ b/scala/README.md
@@ -1,0 +1,13 @@
+Revenj.Scala
+============
+
+[![Build Status](https://travis-ci.org/ngs-doo/revenj.svg?branch=travis)](https://travis-ci.org/ngs-doo/revenj)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.revenj/revenj-core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.revenj/revenj-core_2.11)
+[![Scaladoc](https://javadoc-badge.appspot.com/net.revenj/revenj-core_2.11.svg?label=scaladoc)](http://javadoc-badge.appspot.com/net.revenj/revenj-core_2.11)
+[![License](https://img.shields.io/badge/license-BSD%203--Clause-brightgreen.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
+**revenj.scala** is available on OSSRH / Maven Central:
+
+```scala
+libraryDependencies += "net.revenj" %% "revenj-core" % "0.3.4"
+```

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -8,16 +8,16 @@ lazy val core = (project in file("revenj-core")
     version := "0.4.0",
     libraryDependencies ++= Seq(
       "org.postgresql" % "postgresql" % "9.4.1212",
-      "joda-time" % "joda-time" % "2.9.4", //TODO: will be removed
-      "org.joda" % "joda-convert" % "1.8.1",
+      "joda-time" % "joda-time" % "2.9.6",   // TODO: will be removed
+      "org.joda" % "joda-convert" % "1.8.1", // TODO: will be removed
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.monix" %% "monix" % "2.1.0",
-      "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.7.8",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.7.8",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.7.8",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.7.8",
-      "org.specs2" %% "specs2-scalacheck" % "3.8.3" % Test
+      "io.monix" %% "monix" % "2.1.1",
+      "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.8.4",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.8.4",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.8.4",
+      "org.specs2" %% "specs2-scalacheck" % "3.8.6" % Test
     )
   )
 )
@@ -27,8 +27,8 @@ lazy val akka = (project in file("revenj-akka")
   settings(
   version := "0.4.0",
   libraryDependencies ++= Seq(
-    "com.typesafe" % "config" % "1.3.0",
-    "com.typesafe.akka" %% "akka-http-core" % "2.4.11"
+    "com.typesafe" % "config" % "1.3.1",
+    "com.typesafe.akka" %% "akka-http-core" % "10.0.0"
     )
   )
   dependsOn(core)
@@ -39,7 +39,7 @@ lazy val storage = (project in file("revenj-storage")
   settings(
     version := "0.1.0-SNAPSHOT",
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2-scalacheck" % "3.8.3" % Test
+      "org.specs2" %% "specs2-scalacheck" % "3.8.6" % Test
     )
   )
 )
@@ -83,7 +83,7 @@ lazy val tests = (project in file("tests")
     version := "0.0.0",
     libraryDependencies ++= Seq(
       "com.dslplatform" % "dsl-clc" % "1.8.3" % Test,
-      "org.specs2" %% "specs2-scalacheck" % "3.8.3" % Test,
+      "org.specs2" %% "specs2-scalacheck" % "3.8.6" % Test,
       "ru.yandex.qatools.embed" % "embedded-services" % "1.21" % Test
         exclude ("org.xbib.elasticsearch.plugin", "elasticsearch-river-jdbc")
     ),
@@ -111,37 +111,35 @@ lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   name := baseDirectory.value.getName,
 
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.11.8", "2.12.0"),
-
+  crossScalaVersions := Seq("2.11.8", "2.12.1"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
     "-language:_",
+    "-target:jvm-1.8",
     "-unchecked",
+    "-Xexperimental",
     "-Xfuture",
-    "-Xlint",
+    "-Xlint:_",
     "-Xverify",
+    "-Yno-adapted-args",
+    "-Yrangepos",
     "-Yrepl-sync",
-    "-Ywarn-adapted-args",
     "-Ywarn-dead-code",
-    "-Ywarn-inaccessible",
-    "-Ywarn-infer-any",
-    "-Ywarn-nullary-override",
-    "-Ywarn-nullary-unit",
     "-Ywarn-numeric-widen",
+    "-Ywarn-unused-import",
     "-Ywarn-unused"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 11)) => Seq(
-      "-optimise",
       "-Yclosure-elim",
       "-Yconst-opt",
       "-Ydead-code",
       "-Yinline",
-      "-Yinline-warnings"
+      "-Yinline-warnings:false"
     )
     case _ => Seq(
-      "-Yopt:_"
+      "-opt:_"
     )
   }),
 

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/scala/revenj-akka/src/main/scala/net/revenj/server/handlers/RpcHandler.scala
+++ b/scala/revenj-akka/src/main/scala/net/revenj/server/handlers/RpcHandler.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.model.Uri.Path
 import akka.stream.Materializer
 import akka.util.ByteString
-import net.revenj.patterns.DomainModel
 import net.revenj.server.{ProcessingEngine, ServerCommandDescription, WireSerialization}
 import net.revenj.server.commands.Utils
 

--- a/scala/revenj-core/src/main/scala/net/revenj/PostgresDatabaseNotification.scala
+++ b/scala/revenj-core/src/main/scala/net/revenj/PostgresDatabaseNotification.scala
@@ -108,7 +108,7 @@ private [revenj] class PostgresDatabaseNotification(
       case ex: Exception =>
         try {
           systemState.notify(SystemState.SystemEvent("notification", s"issue: ${ex.getMessage}"))
-          Thread.sleep(1000 * retryCount)
+          Thread.sleep(1000L * retryCount)
         } catch {
           case e: InterruptedException =>
             e.printStackTrace()
@@ -128,7 +128,7 @@ private [revenj] class PostgresDatabaseNotification(
           val messages = connection.getNotifications
           if (messages == null || messages.isEmpty) {
             try {
-              Thread.sleep(timeout)
+              Thread.sleep(timeout.toLong)
             } catch {
               case e: InterruptedException =>
                 threadAlive = false
@@ -219,7 +219,7 @@ Either disable notifications (revenj.notifications.status=disabled), change it t
       case ex: Exception =>
         try {
           systemState.notify(SystemState.SystemEvent("notification", s"issue: ${ex.getMessage}"))
-          Thread.sleep(1000 * retryCount)
+          Thread.sleep(1000L * retryCount)
         } catch {
           case e: InterruptedException =>
             e.printStackTrace()

--- a/scala/revenj-core/src/main/scala/net/revenj/Utils.scala
+++ b/scala/revenj-core/src/main/scala/net/revenj/Utils.scala
@@ -65,7 +65,7 @@ object Utils {
   private class GenArrType(genType: JavaType) extends GenericArrayType {
     lazy private val typeName = genType.getTypeName + "[]"
     override def getGenericComponentType = genType
-    def getTypeName: String = typeName
+    override def getTypeName: String = typeName
     override def toString: String = typeName
   }
 

--- a/scala/revenj-core/src/main/scala/net/revenj/database/postgres/converters/JsonConverter.scala
+++ b/scala/revenj-core/src/main/scala/net/revenj/database/postgres/converters/JsonConverter.scala
@@ -2,7 +2,7 @@ package net.revenj.database.postgres.converters
 
 import java.io.IOException
 
-import net.revenj.database.postgres.{PostgresBuffer, PostgresReader, PostgresWriter}
+import net.revenj.database.postgres.{PostgresBuffer, PostgresReader}
 import net.revenj.serialization.Serialization
 
 class JsonConverter(serialization: Serialization[String]) extends Converter[Map[String, Any]] {


### PR DESCRIPTION
Allow cross-build of Revenj.Scala for 2.11.8 & 2.12.1
Bump SBT to 0.13.13
Bump library dependencies: Jackson Scala, Akka Http, Specs2, ...
Add Travis build for Revenj (for now, Revenj.Scala only)
Tweaked some casts to remove scalac warnings