### PR TITLE
Added "PluginsExclusions"

### DIFF
--- a/csharp/Core/Revenj.Core/Extensibility/Plugins/PluginsProvider.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Plugins/PluginsProvider.cs
@@ -54,8 +54,8 @@ namespace Revenj.Extensibility
 			{
 				if (directory != null)
 				{
-				    var exclusions = ConfigurationManager.AppSettings["PluginsExclusions"];
-                    var files = Directory.EnumerateFiles(directory, "*.dll").Where(f => !Util.FilenameMatch(f, exclusions)).ToList();
+					var exclusions = ConfigurationManager.AppSettings["PluginsExclusions"];
+					var files = Directory.EnumerateFiles(directory, "*.dll").Where(f => !Util.FilenameMatch(f, exclusions)).ToList();
 					foreach (var f in files)
 					{
 						var name = Path.GetFileNameWithoutExtension(f);

--- a/csharp/Core/Revenj.Core/Extensibility/Plugins/PluginsProvider.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Plugins/PluginsProvider.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
+using System.Configuration;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using Revenj.Common;
+using Revenj.Core.Utility;
 using Revenj.Extensibility.Autofac.Core;
 using Revenj.Utility;
 
@@ -52,7 +54,9 @@ namespace Revenj.Extensibility
 			{
 				if (directory != null)
 				{
-					foreach (var f in Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
+				    var exclusions = ConfigurationManager.AppSettings["PluginsExclusions"];
+                    var files = Directory.EnumerateFiles(directory, "*.dll").Where(f => !Util.FilenameMatch(f, exclusions)).ToList();
+					foreach (var f in files)
 					{
 						var name = Path.GetFileNameWithoutExtension(f);
 						//TODO: temporary hack, will clean up later

--- a/csharp/Core/Revenj.Core/Revenj.Core.csproj
+++ b/csharp/Core/Revenj.Core/Revenj.Core.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Utility\TemporaryResources.cs" />
     <Compile Include="Utility\TopologicalSort.cs" />
     <Compile Include="Utility\TreePath.cs" />
+    <Compile Include="Utility\Util.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\..\CodeAnalysisDictionary.xml">

--- a/csharp/Core/Revenj.Core/Utility/Util.cs
+++ b/csharp/Core/Revenj.Core/Utility/Util.cs
@@ -5,21 +5,21 @@ using System.Text.RegularExpressions;
 
 namespace Revenj.Core.Utility
 {
-    public static class Util
-    {
-        public static bool FilenameMatch(string filePath, string commaSeparatedWildcards)
-        {
-            if (string.IsNullOrWhiteSpace(filePath))
-                throw new ArgumentNullException(nameof(filePath));
+	public static class Util
+	{
+		public static bool FilenameMatch(string filePath, string commaSeparatedWildcards)
+		{
+			if (string.IsNullOrWhiteSpace(filePath))
+				throw new ArgumentNullException(nameof(filePath));
 
-            var filename = Path.GetFileName(filePath).ToLower();
-            return commaSeparatedWildcards != null && commaSeparatedWildcards.ToLower().Split(',')
-                       .Any(wildcard => Regex.IsMatch(filename, WildcardToRegExPattern(wildcard)));
-        }
+			var filename = Path.GetFileName(filePath).ToLower();
+			return commaSeparatedWildcards != null && commaSeparatedWildcards.ToLower().Split(',')
+						.Any(wildcard => Regex.IsMatch(filename, WildcardToRegExPattern(wildcard)));
+		}
 
-        public static string WildcardToRegExPattern(string value)
-        {
-            return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
-        }
-    }
+		public static string WildcardToRegExPattern(string value)
+		{
+			return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
+		}
+	}
 }

--- a/csharp/Core/Revenj.Core/Utility/Util.cs
+++ b/csharp/Core/Revenj.Core/Utility/Util.cs
@@ -12,7 +12,7 @@ namespace Revenj.Core.Utility
 			if (string.IsNullOrWhiteSpace(filePath))
 				throw new ArgumentNullException(nameof(filePath));
 
-			var filename = Path.GetFileName(filePath).ToLower();
+			var filename = Path.GetFileNameWithoutExtension(filePath).ToLower();
 			return commaSeparatedWildcards != null && commaSeparatedWildcards.ToLower().Split(',')
 						.Any(wildcard => Regex.IsMatch(filename, WildcardToRegExPattern(wildcard)));
 		}

--- a/csharp/Core/Revenj.Core/Utility/Util.cs
+++ b/csharp/Core/Revenj.Core/Utility/Util.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Revenj.Core.Utility
+{
+    public static class Util
+    {
+        public static bool FilenameMatch(string filePath, string commaSeparatedWildcards)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+
+            var filename = Path.GetFileName(filePath).ToLower();
+            return commaSeparatedWildcards != null && commaSeparatedWildcards.ToLower().Split(',')
+                       .Any(wildcard => Regex.IsMatch(filename, WildcardToRegExPattern(wildcard)));
+        }
+
+        public static string WildcardToRegExPattern(string value)
+        {
+            return "^" + Regex.Escape(value).Replace("\\?", ".").Replace("\\*", ".*") + "$";
+        }
+    }
+}

--- a/csharp/Server/Revenj.Http/App.config
+++ b/csharp/Server/Revenj.Http/App.config
@@ -5,6 +5,7 @@
   </configSections>
   <appSettings>
     <add key="PluginsPath" value="." />
+    <!--<add key="PluginsExclusions" value="ThirdPartyLibrary.dll,Oracle.DataAccess*,Revenj.DatabasePersistence.Oracle*,DevExpress*" />-->
     <add key="ApplicationMode" value="Debug" />
     <add key="ServerAssembly" value="../../cache/GeneratedModel.dll"/>
     <add key="ConnectionString" value="server=localhost;port=5432;database=revenj;user=revenj;password=revenj;encoding=unicode" />

--- a/csharp/Server/Revenj.Http/App.config
+++ b/csharp/Server/Revenj.Http/App.config
@@ -5,7 +5,7 @@
   </configSections>
   <appSettings>
     <add key="PluginsPath" value="." />
-    <!--<add key="PluginsExclusions" value="ThirdPartyLibrary.dll,Oracle.DataAccess*,Revenj.DatabasePersistence.Oracle*,DevExpress*" />-->
+    <!--<add key="PluginsExclusions" value="ThirdPartyLibrary,DevExpress*" />-->
     <add key="ApplicationMode" value="Debug" />
     <add key="ServerAssembly" value="../../cache/GeneratedModel.dll"/>
     <add key="ConnectionString" value="server=localhost;port=5432;database=revenj;user=revenj;password=revenj;encoding=unicode" />


### PR DESCRIPTION
The PluginsProvider currently loads all the .dll files in the Plugins path and that slows down the start-up with a few seconds when an user's plugin also references other third party assemblies (for example in our case: 35 DevExpress dlls totalling 92 MBs)

The "PluginsExclusions" value is a comma separated list of filenames and supports wildcards, for example:

<configuration>
  <appSettings>
    <add key="PluginsExclusions" value="ThirdPartyLibrary.dll,Oracle.DataAccess*,Revenj.DatabasePersistence.Oracle*,DevExpress*" />