### PR TITLE
Use `typeOf` from runtime mirror

### DIFF
--- a/scala/revenj-core/src/main/scala/net/revenj/ServicesPluginLoader.scala
+++ b/scala/revenj-core/src/main/scala/net/revenj/ServicesPluginLoader.scala
@@ -17,11 +17,11 @@ private[revenj] class ServicesPluginLoader(loader: ClassLoader) extends PluginLo
 
   def find[T: TypeTag]: Seq[Class[T]] = {
     val plugins = new ArrayBuffer[Class[T]]()
-    val scalaType = typeOf[T].dealias
+    val scalaType = mirror.typeOf[T].dealias
     val javaTypeName = Utils.findType(scalaType, mirror).map(_.getTypeName).getOrElse(scalaType.toString).replace(" ", "")
 
     val fullName = PREFIX + URLEncoder.encode(javaTypeName, "UTF-8")
-    val manifest = mirror.runtimeClass(typeOf[T].dealias).asInstanceOf[Class[T]]
+    val manifest = mirror.runtimeClass(scalaType).asInstanceOf[Class[T]]
     //TODO: release class loader to avoid locking up jars on Windows
     val configs = loader.getResources(fullName)
     val foundServices = mutable.Set[String]()

--- a/scala/revenj-core/src/main/scala/net/revenj/extensibility/PluginLoader.scala
+++ b/scala/revenj-core/src/main/scala/net/revenj/extensibility/PluginLoader.scala
@@ -13,7 +13,8 @@ trait PluginLoader {
   }
   def resolve[T : TypeTag](container: Container): Array[T] = {
     val loader = container.resolve[ClassLoader]
-    Utils.findType(typeOf[T], runtimeMirror(loader)) match {
+    val mirror = runtimeMirror(loader)
+    Utils.findType(mirror.typeOf[T], mirror) match {
       case Some(tpe) =>
         val scope = container.createScope()
         try {
@@ -24,7 +25,7 @@ trait PluginLoader {
         } finally {
           scope.close()
         }
-      case _ => throw new IllegalArgumentException(s"Unable to resolve plugins for provided type: ${typeOf[T]}")
+      case _ => throw new IllegalArgumentException(s"Unable to resolve plugins for provided type: ${mirror.typeOf[T]}")
     }
   }
 }


### PR DESCRIPTION
Required to be able to resolve generic classes in scope. Previously,
this was causing exceptions on certain occasions when an alternative
class loader such as Play's was used.