### PR TITLE
[Feature] Visibility management improvements

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -69,7 +69,7 @@
     "scripts",
     "README.md"
   ],
-  "license": "BSD-3-Clause License",
+  "license": "BSD-3-Clause",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.modern.js",

--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -95,5 +95,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/typescript-react/src/components/DslApplication/DslApplication.tsx
+++ b/typescript-react/src/components/DslApplication/DslApplication.tsx
@@ -8,9 +8,10 @@ import { INavigationContext, NavigationContext } from '../Navigation/NavigationC
 import { INotificationContext, NotificationContext } from '../Notification/NotificationContext';
 import { LoaderContext, ILoaderContext } from '../Loader/Loader';
 
-export interface IDslApplication extends IApiContext, Partial<II18nContext>, INavigationContext, INotificationContext, ILoaderContext, IFieldRegistryContext {
+export interface IDslApplication extends IApiContext, Partial<II18nContext>, INavigationContext, INotificationContext, ILoaderContext, Omit<IFieldRegistryContext, 'Visibility'> {
   api: IApiService;
   marshalling: IBootConfig;
+  Visibility?: IFieldRegistryContext['Visibility'];
 }
 
 export interface IDslApplicationState {
@@ -30,7 +31,7 @@ export class DslApplication extends React.PureComponent<IDslApplication, IDslApp
   public state: IDslApplicationState = {
     api: { ExportButton: this.props.ExportButton, onExport: this.props.onExport, getS3DownloadUrl: this.props.getS3DownloadUrl },
     i18n: { localize: this.props.localize! },
-    fields: { Fields: this.props.Fields, defaults: this.props.defaults, validators: this.props.validators },
+    fields: { Fields: this.props.Fields, defaults: this.props.defaults, validators: this.props.validators, Visibility: this.props.Visibility ?? {} },
     loading: { LoadingComponent: this.props.LoadingComponent },
     navigation: { Link: this.props.Link },
     notification: { notifyError: this.props.notifyError },
@@ -66,9 +67,14 @@ export class DslApplication extends React.PureComponent<IDslApplication, IDslApp
       });
     }
 
-    if (this.props.Fields !== prevProps.Fields || this.props.defaults !== prevProps.defaults || this.props.validators !== prevProps.validators) {
+    if (
+      this.props.Fields !== prevProps.Fields ||
+      this.props.defaults !== prevProps.defaults ||
+      this.props.validators !== prevProps.validators ||
+      this.props.Visibility !== prevProps.Visibility
+    ) {
       this.setState({
-        fields: { Fields: this.props.Fields, defaults: this.props.defaults, validators: this.props.validators },
+        fields: { Fields: this.props.Fields, defaults: this.props.defaults, validators: this.props.validators, Visibility: this.props.Visibility ?? {} },
       });
     }
 

--- a/typescript-react/src/components/FieldRegistry/FieldRegistryContext.ts
+++ b/typescript-react/src/components/FieldRegistry/FieldRegistryContext.ts
@@ -23,6 +23,10 @@ export interface IFields {
   [key: string]: React.ComponentType<IExternalFormField<any, any, any>>;
 }
 
+export interface IVisibilityFunctions {
+  [key: string]: (...args: any[]) => boolean;
+}
+
 // NOTE: This is not typesafe, unfortunately. It would be nice to figure out a way to constrain these in some way, otherwise
 // it will be possible for the generated code to produce some weird results. This is not a problem per se, since we can make
 // sure the generated code generally makes sense, but user-defined defaults and validators might be wonky
@@ -30,6 +34,7 @@ export interface IFieldRegistryContext {
   Fields: IFields;
   validators: { [key: string]: Validator<any, any, any> | ((...args: any[]) => Validator<any, any, any>) };
   defaults: { [key: string]: any };
+  Visibility: IVisibilityFunctions;
 }
 
 const ImplementationMissing: React.FC<IExternalFormField<any, any, any>> = () => {
@@ -53,6 +58,7 @@ const defaultContext: IFieldRegistryContext = {
   },
   defaults: {},
   validators: {},
+  Visibility: {},
 };
 
 export const FieldRegistryContext = React.createContext<IFieldRegistryContext>(defaultContext);

--- a/typescript-react/src/components/FieldRegistry/WithVisibility.tsx
+++ b/typescript-react/src/components/FieldRegistry/WithVisibility.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { IVisibilityFunctions, FieldRegistryContext } from './FieldRegistryContext';
+
+interface IWithVisibility {
+  predicates: IVisibilityFunctions;
+}
+
+export const WithVisibility: React.FC<IWithVisibility> = React.memo(({ predicates, children }) => (
+  <FieldRegistryContext.Consumer>
+    {
+      (ctx) => (
+        <FieldRegistryContext.Provider value={{ ...ctx, Visibility: { ...ctx.Visibility, ...predicates }}}>
+          {children}
+        </FieldRegistryContext.Provider>
+      )
+    }
+  </FieldRegistryContext.Consumer>
+));

--- a/typescript-react/src/components/Form/Context.ts
+++ b/typescript-react/src/components/Form/Context.ts
@@ -64,6 +64,7 @@ export const CreatePresenterContext = React.createContext<ICreatePresenterContex
 
 export interface IFormContext<T> {
   form: string;
+  clearOnUnmount?: boolean;
   formType?: FormType;
   sectionName?: string;
   initialValues?: Partial<T>;
@@ -89,7 +90,7 @@ export const GlobalFormsContext = React.createContext<IGlobalFormsContext>({
   isGroupVisible: () => true,
 });
 
-export type FormControlDescriptor<T, K extends keyof T> = Partial<Omit<IExternalFormField<T, K, T[K]>, 'name'>> & { visible?: boolean; };
+export type FormControlDescriptor<T, K extends keyof T> = Partial<Omit<IExternalFormField<T, K, T[K]>, 'name'>>;
 
 export type IFormControlContext<T> = {
   [K in keyof T]?: T[K] extends Array<any>

--- a/typescript-react/src/components/Form/Group.tsx
+++ b/typescript-react/src/components/Form/Group.tsx
@@ -63,16 +63,16 @@ export class GroupBare<T = any> extends React.PureComponent<IGroup<T>> {
           name={Array.isArray(name) ? name.join('.') : name as string}
           {...extraProps}
         >
-          <FormContextProvider value={{ ...rest, sectionName: this.getNestedSectionName() }}>
+          <FormContextProvider value={{ ...rest, sectionName: this.getNestedSectionName(), clearOnUnmount: true }}>
             {childElement}
           </FormContextProvider>
         </FormSection>
       );
     } else {
       return (
-        <React.Fragment>
+        <FormContextProvider value={{ ...rest, sectionName, clearOnUnmount: true }}>
           {childElement}
-        </React.Fragment>
+        </FormContextProvider>
       );
     }
   }

--- a/typescript-react/src/components/index.ts
+++ b/typescript-react/src/components/index.ts
@@ -58,3 +58,4 @@ export { ListPresenter } from './Presenters/ListPresenter';
 export { Report } from './Presenters/ReportPresenter';
 export { ViewEditPresenter } from './Presenters/ViewEditPresenter';
 export { FieldRegistryContext } from './FieldRegistry/FieldRegistryContext';
+export { WithVisibility } from './FieldRegistry/WithVisibility';


### PR DESCRIPTION
A common use case in forms is the need to control the visibility of sections or controls via some predicate. So far, it was available only on the group level, and only with inline functions.

Expose a registry for utilities for visibility that can be used straight from DSL after registration as `this.context.Visibility.yourFunction`.

Furthermore, expose a `visible` property (either static or dynamic) on the fields/controls themselves. Manage its clearing of values when it's in a possibly invisible context, so that we do not have dead values lying around.

Tweak the license name to match the standard