### PR TITLE
[React] Layout Improvements

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -95,5 +95,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/typescript-react/src/components/Form/Context.ts
+++ b/typescript-react/src/components/Form/Context.ts
@@ -70,6 +70,7 @@ export interface IFormContext<T> {
   initialValues?: Partial<T>;
   readOnly?: boolean;
   forceOptional?: boolean;
+  defaultInline?: boolean;
   submitErrors?: FormErrors<T>;
   reset: () => void;
   change: <K extends DeepKeyOf<T>>(field: K, value: DeepTypeOf<T, K>) => void;

--- a/typescript-react/src/components/Form/FormField.tsx
+++ b/typescript-react/src/components/Form/FormField.tsx
@@ -240,6 +240,7 @@ export function FormField<T, K extends DeepKeyOf<T>, P = any, V = any>(props: IF
   const disabled = configProps?.disabled ?? props.disabled;
   const readOnly = configProps?.readOnly ?? context.readOnly ?? props.readOnly;
   const rawLabel = configProps?.label ?? props.label;
+  const inline = configProps?.inline ?? props.inline ?? context.defaultInline;
 
   if (visible === false || (typeof visible === 'function' && !visible(values))) {
     return null;
@@ -260,6 +261,7 @@ export function FormField<T, K extends DeepKeyOf<T>, P = any, V = any>(props: IF
       readOnly={typeof readOnly === 'function' ? readOnly(values) : readOnly}
       disabled={typeof disabled === 'function' ? disabled(values) : disabled}
       label={rawLabel ? localizeTextIfMarked(localize, rawLabel) : undefined}
+      inline={inline}
       // Fields that can appear and vanish must be able to clear themselves when unmounting, we don't want stale invisible values
       clearOnUnmount={props.clearOnUnmount || context.clearOnUnmount || configProps.clearOnUnmount || visible != null}
     />

--- a/typescript-react/src/components/Form/FormSection.module.css
+++ b/typescript-react/src/components/Form/FormSection.module.css
@@ -32,8 +32,10 @@
 
 /* NOTE: Ideally, we would have CSS-in-JS at this point, since it's an UI lib, but we can at least force generated code to behave */
 .Section.Vertical > .Items :global .dslField {
+  min-width: 100%;
   max-width: 100%;
   width: 100%;
+  margin-right: 0;
 }
 
 .Section .Header {
@@ -72,4 +74,51 @@
 /* Indent deeper sections, as we've run out of special title styles */
 .Section.Titled .Section.Titled .Section.Titled .Section.Titled .Section.Titled .Section {
   margin-left: 32px;
+}
+
+.Section.SingleColumn > .Items > :global(.dslField),
+.Section.SingleColumn > .Items > .Section {
+  width: 100%;
+  max-width: 100%;
+  margin-right: 0;
+}
+
+.Section.TwoColumns > .Items > :global(.dslField),
+.Section.TwoColumns > .Items > .Section.Vertical {
+  width: calc((100% - 16px) / 2);
+  max-width: calc((100% - 16px) / 2);
+  margin-right: 16px;
+}
+
+.Section.TwoColumns > .Items > :global(.dslField):nth-child(2),
+.Section.TwoColumns > .Items > .Section.Vertical:nth-child(2) {
+  margin-right: 0;
+}
+
+.Section.ThreeColumns > .Items > :global(.dslField),
+.Section.ThreeColumns > .Items > .Section.Vertical {
+  width: calc((100% - 32px) / 3);
+  max-width: calc((100% - 32px) / 3);
+  margin-right: 16px;
+}
+
+.Section.ThreeColumns > .Items > :global(.dslField):nth-child(3),
+.Section.ThreeColumns > .Items > .Section.Vertical:nth-child(3) {
+  margin-right: 0;
+}
+
+.Section.TwoColumns > .Items > .Section.Vertical,
+.Section.ThreeColumns > .Items > .Section.Vertical {
+  align-self: flex-start;
+}
+
+@media (max-width: 767px) {
+  .Section.TwoColumns > .Items > :global(.dslField),
+  .Section.TwoColumns > .Items > .Section.Vertical,
+  .Section.ThreeColumns > .Items > :global(.dslField),
+  .Section.ThreeColumns > .Items > .Section.Vertical {
+    width: 100%;
+    max-width: 100%;
+    margin-right: 0;
+  }
 }

--- a/typescript-react/src/components/Form/Group.tsx
+++ b/typescript-react/src/components/Form/Group.tsx
@@ -23,6 +23,7 @@ interface IGroupPublicProps<T> {
   height?: number;
   className?: string;
   containerClassName?: string;
+  columns?: 1 | 2 | 3;
 }
 
 interface IGroupInjectedProps<T> {
@@ -37,7 +38,20 @@ export class GroupBare<T = any> extends React.PureComponent<IGroup<T>> {
   public context: React.ContextType<typeof FormContext>;
 
   public render() {
-    const { borderless, children, containerClassName, className, vertical, name, visibility, optional, values, height, ...props } = this.props;
+    const {
+      borderless,
+      children,
+      containerClassName,
+      columns,
+      className,
+      vertical,
+      name,
+      visibility,
+      optional,
+      values,
+      height,
+      ...props
+    } = this.props;
     const { sectionName, ...rest } = this.context!;
 
     if (!this.isVisible()) {
@@ -47,7 +61,19 @@ export class GroupBare<T = any> extends React.PureComponent<IGroup<T>> {
     const childElement = (
       <Section
         {...props}
-        containerClassName={classNames(styles.Section, { [styles.Vertical]: vertical, [styles.Borderless]: borderless, [styles.Titled]: !!props.title }, className, 'dslGroup')}
+        containerClassName={classNames(
+          styles.Section,
+          {
+            [styles.Vertical]: vertical,
+            [styles.Borderless]: borderless,
+            [styles.Titled]: !!props.title,
+            [styles.SingleColumn]: columns === 1,
+            [styles.TwoColumns]: columns === 2,
+            [styles.ThreeColumns]: columns === 3,
+          },
+          className,
+          'dslGroup',
+        )}
         keepExpanded={!this.collapseInitially()}
       >
         {children}
@@ -64,14 +90,14 @@ export class GroupBare<T = any> extends React.PureComponent<IGroup<T>> {
           name={Array.isArray(name) ? name.join('.') : name as string}
           {...extraProps}
         >
-          <FormContextProvider value={{ ...rest, sectionName: this.getNestedSectionName(), clearOnUnmount: true, forceOptional: optional ?? undefined }}>
+          <FormContextProvider value={{ ...rest, sectionName: this.getNestedSectionName(), clearOnUnmount: true, forceOptional: optional ?? undefined, defaultInline: vertical }}>
             {childElement}
           </FormContextProvider>
         </FormSection>
       );
     } else {
       return (
-        <FormContextProvider value={{ ...rest, sectionName, clearOnUnmount: true, forceOptional: optional ?? undefined }}>
+        <FormContextProvider value={{ ...rest, sectionName, clearOnUnmount: true, forceOptional: optional ?? undefined, defaultInline: vertical }}>
           {childElement}
         </FormContextProvider>
       );


### PR DESCRIPTION
Add an opinionated default of vertical forms, by default, forcing their fields to be inline.
This can easily be overriden.

Add a columns prop to Group, which can be used to force a layout on children fields or vertical Groups.
Make it support 1 | 2 | 3, for the time being.

Release as 1.7.0