### PR TITLE
Updated integer validations

### DIFF
--- a/typescript-react/src/components/validation/__tests__/__snapshots__/type.spec.ts.snap
+++ b/typescript-react/src/components/validation/__tests__/__snapshots__/type.spec.ts.snap
@@ -14,6 +14,10 @@ exports[`validation isIntegerCreator should return an error when value exists bu
 
 exports[`validation isIntegerCreator should return an error when value exists but is not treatable as an integer 7`] = `"Value must be an integer."`;
 
+exports[`validation isIntegerCreator should return an error when value exists but is not treatable as an integer 8`] = `"Value must be an integer."`;
+
+exports[`validation isIntegerCreator should return an error when value exists but is not treatable as an integer 9`] = `"Value must be an integer."`;
+
 exports[`validation isNumberCreator should return an error when value exists but is not treatable as a numeric value 1`] = `"Value must be a number."`;
 
 exports[`validation isNumberCreator should return an error when value exists but is not treatable as a numeric value 2`] = `"Value must be a number."`;

--- a/typescript-react/src/components/validation/__tests__/type.spec.ts
+++ b/typescript-react/src/components/validation/__tests__/type.spec.ts
@@ -4,6 +4,10 @@ import {
   isIntegerCreator,
   isNumberCreator,
 } from '../type';
+import {
+  INT_MAX_VALUE,
+  INT_MIN_VALUE,
+} from '../../../constants';
 
 describe('validation', () => {
   describe('isNumberCreator', () => {
@@ -37,6 +41,8 @@ describe('validation', () => {
       expect(isInteger(null as any, {})).toBeUndefined();
       expect(isInteger('0', {})).toBeUndefined();
       expect(isInteger('123', {})).toBeUndefined();
+      expect(isInteger(`${INT_MAX_VALUE}`, {})).toBeUndefined();
+      expect(isInteger(`${INT_MIN_VALUE}`)).toBeUndefined();
     });
 
     it('should return an error when value exists but is not treatable as an integer', () => {
@@ -54,6 +60,10 @@ describe('validation', () => {
       expect(isInteger('2.2', {})).toMatchSnapshot();
       expect(isInteger(new BigNumber(2.2), {})).toBeDefined();
       expect(isInteger(new BigNumber(2.2), {})).toMatchSnapshot();
+      expect(isInteger(INT_MAX_VALUE + 1, {})).toBeDefined();
+      expect(isInteger(INT_MAX_VALUE + 1, {})).toMatchSnapshot();
+      expect(isInteger(INT_MIN_VALUE - 1, {})).toBeDefined();
+      expect(isInteger(INT_MIN_VALUE - 1, {})).toMatchSnapshot();
     });
   });
 });

--- a/typescript-react/src/components/validation/index.ts
+++ b/typescript-react/src/components/validation/index.ts
@@ -1,4 +1,8 @@
 import {
+  INT_MAX_VALUE,
+  INT_MIN_VALUE,
+} from '../../constants';
+import {
   parseBigNum,
   Numeric,
   ZERO,
@@ -59,7 +63,7 @@ export const isNumberCreator = (message: string = 'Please enter a number') =>
     getValidatorErrorMessageOverride: message,
   });
 
-export const isIntegerCreator = (message: string = 'Must be a whole number') =>
+export const isIntegerCreator = (message: string = `Must be a whole number between ${INT_MIN_VALUE} and ${INT_MAX_VALUE}`) =>
   type.isIntegerCreator({
     getValidatorErrorMessageOverride: message,
   });

--- a/typescript-react/src/components/validation/index.ts
+++ b/typescript-react/src/components/validation/index.ts
@@ -1,8 +1,4 @@
 import {
-  INT_MAX_VALUE,
-  INT_MIN_VALUE,
-} from '../../constants';
-import {
   parseBigNum,
   Numeric,
   ZERO,
@@ -63,7 +59,7 @@ export const isNumberCreator = (message: string = 'Please enter a number') =>
     getValidatorErrorMessageOverride: message,
   });
 
-export const isIntegerCreator = (message: string = `Must be a whole number between ${INT_MIN_VALUE} and ${INT_MAX_VALUE}`) =>
+export const isIntegerCreator = (message: string = `Must be a whole number with up to 10 digits`) =>
   type.isIntegerCreator({
     getValidatorErrorMessageOverride: message,
   });

--- a/typescript-react/src/components/validation/type.ts
+++ b/typescript-react/src/components/validation/type.ts
@@ -1,3 +1,7 @@
+import {
+  INT_MAX_VALUE,
+  INT_MIN_VALUE,
+} from '../../constants';
 import { Numeric, parseBigNum } from '../../util/NumberUtils/NumberUtils';
 import { ValidateTrigger } from './interfaces';
 import { validatorCreatorFactory } from './validatorCreatorFactory';
@@ -11,12 +15,13 @@ export const isIntegerCreator =
     operator: () => (input) => {
       try {
         const aNumber = parseBigNum(input);
+        // string can be of form 0.00 which is an integer, but the string value is written in a non-integer notation
+        const isInteger = !aNumber.isNaN() && aNumber.isInteger() &&  Number(input) <= INT_MAX_VALUE && Number(input) >= INT_MIN_VALUE;
         if (typeof input === 'string') {
-          // string can be of form 0.00 which is an integer, but the string value is written in a non-integer notation
-          return !aNumber.isNaN() && aNumber.isInteger() && /^(?:\+|-)?\d+$/.test(input);
-        } else {
-          return !aNumber.isNaN() && aNumber.isInteger();
+          return isInteger && /^(?:\+|-)?\d+$/.test(input);
         }
+        
+        return isInteger;
       } catch {
         return false;
       }

--- a/typescript-react/src/constants.ts
+++ b/typescript-react/src/constants.ts
@@ -1,2 +1,4 @@
+export const INT_MAX_VALUE = 2147483647;
+export const INT_MIN_VALUE = -2147483648;
 export const SHORT_MAX_VALUE = 32767;
 export const SHORT_MIN_VALUE = -32768;

--- a/typescript-react/src/marshalling/__tests__/__snapshots__/assert.spec.ts.snap
+++ b/typescript-react/src/marshalling/__tests__/__snapshots__/assert.spec.ts.snap
@@ -12,11 +12,15 @@ exports[`data marshalling asserting assertEnum should test that the value is one
 
 exports[`data marshalling asserting assertEnum should test that the value is one of the provided values 3`] = `"Value is required, but is not set!"`;
 
-exports[`data marshalling asserting assertInt should explode on non-integers 1`] = `"Expected an Int, but value is bla"`;
+exports[`data marshalling asserting assertInt should explode on non-integers 1`] = `"Expected an Int, but value is -2147483649"`;
 
-exports[`data marshalling asserting assertInt should explode on non-integers 2`] = `"Expected an Int, but value is null"`;
+exports[`data marshalling asserting assertInt should explode on non-integers 2`] = `"Expected an Int, but value is bla"`;
 
-exports[`data marshalling asserting assertInt should explode on non-integers 3`] = `"Expected an Int, but value is 1.55"`;
+exports[`data marshalling asserting assertInt should explode on non-integers 3`] = `"Expected an Int, but value is null"`;
+
+exports[`data marshalling asserting assertInt should explode on non-integers 4`] = `"Expected an Int, but value is 1.55"`;
+
+exports[`data marshalling asserting assertInt should explode on non-integers 5`] = `"Expected an Int, but value is 2147483648"`;
 
 exports[`data marshalling asserting assertLong should explode on non-longs 1`] = `"Expected a Long, but value is bla"`;
 

--- a/typescript-react/src/marshalling/__tests__/assert.spec.ts
+++ b/typescript-react/src/marshalling/__tests__/assert.spec.ts
@@ -1,4 +1,8 @@
 import {
+  INT_MAX_VALUE,
+  INT_MIN_VALUE,
+} from '../../constants';
+import {
   ColumnType,
   TypescriptResultSet,
 } from '../../ResultSet/ResultSet';
@@ -66,14 +70,14 @@ ing`];
 
   describe('assertInt', () => {
     it('should pass through valid integers', () => {
-      const valids = [-10, 0, 235] as Int[];
+      const valids = [INT_MIN_VALUE, -10, 0, 235, INT_MAX_VALUE] as Int[];
       for (const valid of valids) {
         expect(Assert.assertInt(valid)).toBe(valid);
       }
     });
 
     it('should explode on non-integers', () => {
-      const invalids = ['bla', null, 1.55] as any[];
+      const invalids = [INT_MIN_VALUE - 1, 'bla', null, 1.55, INT_MAX_VALUE + 1] as any[];
       for (const invalid of invalids) {
         expect(() => Assert.assertInt(invalid)).toThrowErrorMatchingSnapshot();
       }

--- a/typescript-react/src/marshalling/assert.ts
+++ b/typescript-react/src/marshalling/assert.ts
@@ -1,6 +1,8 @@
 
 import { TypescriptResultSet } from '../ResultSet/ResultSet';
 import {
+  INT_MAX_VALUE,
+  INT_MIN_VALUE,
   SHORT_MAX_VALUE,
   SHORT_MIN_VALUE,
 } from '../constants';
@@ -45,7 +47,8 @@ export const assertString = <T extends string>(value: T, length?: number): T => 
 
 export const assertInt = <T extends Int>(value: T): T => {
   const number = Number.parseInt(String(value), 10) as T;
-  if (Number.isNaN(number) || typeof value !== 'number' || value !== number) {
+
+  if (Number.isNaN(number) || value > INT_MAX_VALUE || value < INT_MIN_VALUE || typeof value !== 'number' || value !== number) {
     throw new Error(`Expected an Int, but value is ${value}`);
   }
   return number;


### PR DESCRIPTION
Added a check to ensure the number is within bounds of a signed 32 bit number.
It was needed because serialization and deserialization would start failing on large numbers.

Also, I couldn't find how snapshots are generated, there's nothing in the code, so I edited them manually.
Please, check if that's alright, because it shouldn't be the way to handle snapshots.