### PR TITLE
Autofac services order

### DIFF
--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/MetadataKeys.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/MetadataKeys.cs
@@ -1,0 +1,34 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2016 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+namespace Revenj.Extensibility.Autofac.Builder
+{
+	internal static class MetadataKeys
+	{
+		internal const string RegistrationOrderMetadataKey = "__RegistrationOrder";
+
+		internal const string AutoActivated = "__AutoActivated";
+	}
+}

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/RegistrationData.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/RegistrationData.cs
@@ -50,7 +50,6 @@ namespace Revenj.Extensibility.Autofac.Builder
 		InstanceOwnership _ownership = InstanceOwnership.OwnedByLifetimeScope;
 		IComponentLifetime _lifetime = new CurrentScopeLifetime();
 		InstanceSharing _sharing = InstanceSharing.None;
-		readonly Dictionary<string, object> _metadata = new Dictionary<string, object>();
 		readonly List<EventHandler<PreparingEventArgs>> _preparingHandlers = new List<EventHandler<PreparingEventArgs>>();
 		readonly List<EventHandler<ActivatingEventArgs<object>>> _activatingHandlers = new List<EventHandler<ActivatingEventArgs<object>>>();
 		readonly List<EventHandler<ActivatedEventArgs<object>>> _activatedHandlers = new List<EventHandler<ActivatedEventArgs<object>>>();
@@ -64,6 +63,10 @@ namespace Revenj.Extensibility.Autofac.Builder
 		{
 			if (defaultService == null) throw new ArgumentNullException("defaultService");
 			_defaultService = defaultService;
+			Metadata = new Dictionary<string, object>
+			{
+				{ MetadataKeys.RegistrationOrderMetadataKey, SequenceGenerator.GetNextUniqueSequence() }
+			};
 		}
 
 		/// <summary>
@@ -135,7 +138,7 @@ namespace Revenj.Extensibility.Autofac.Builder
 		/// <summary>
 		/// Extended properties assigned to the component.
 		/// </summary>
-		public IDictionary<string, object> Metadata { get { return _metadata; } }
+		public IDictionary<string, object> Metadata { get; }
 
 		/// <summary>
 		/// Handlers for the Preparing event.
@@ -169,7 +172,7 @@ namespace Revenj.Extensibility.Autofac.Builder
 				_defaultService = that._defaultService;
 
 			AddAll(_services, that._services);
-			AddAll(Metadata, that.Metadata);
+			AddAll(Metadata, that.Metadata.Where(m => m.Key != MetadataKeys.RegistrationOrderMetadataKey));
 			AddAll(PreparingHandlers, that.PreparingHandlers);
 			AddAll(ActivatingHandlers, that.ActivatingHandlers);
 			AddAll(ActivatedHandlers, that.ActivatedHandlers);

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/RegistrationOrderExtensions.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Builder/RegistrationOrderExtensions.cs
@@ -1,0 +1,49 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2016 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using Revenj.Extensibility.Autofac.Core;
+
+namespace Revenj.Extensibility.Autofac.Builder
+{
+	internal static class RegistrationOrderExtensions
+	{
+		internal static long GetRegistrationOrder(this IComponentRegistration registration)
+		{
+			object value;
+			return registration.Metadata.TryGetValue(MetadataKeys.RegistrationOrderMetadataKey, out value) ? (long)value : long.MaxValue;
+		}
+
+		internal static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> InheritRegistrationOrderFrom<TLimit, TActivatorData, TSingleRegistrationStyle>(
+				this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+				IComponentRegistration source)
+			where TSingleRegistrationStyle : SingleRegistrationStyle
+		{
+			var sourceRegistrationOrder = source.GetRegistrationOrder();
+			registration.RegistrationData.Metadata[MetadataKeys.RegistrationOrderMetadataKey] = sourceRegistrationOrder;
+
+			return registration;
+		}
+	}
+}

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Revenj.Extensibility.Autofac.Builder;
 using Revenj.Extensibility.Autofac.Core;
 using Revenj.Extensibility.Autofac.Core.Activators.Delegate;
 using Revenj.Extensibility.Autofac.Core.Lifetime;
@@ -76,7 +77,7 @@ namespace Revenj.Extensibility.Autofac.Features.Collections
 						Guid.NewGuid(),
 						new DelegateActivator(elementArrayType, (c, p) =>
 						{
-							var elements = c.ComponentRegistry.RegistrationsFor(elementTypeService);
+							var elements = c.ComponentRegistry.RegistrationsFor(elementTypeService).OrderBy(cr => cr.GetRegistrationOrder());
 							var items = elements.Select(cr => c.ResolveComponent(service, cr, p)).ToArray();
 							var result = Array.CreateInstance(elementType, items.Length);
 							items.CopyTo(result, 0);

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
@@ -66,7 +66,8 @@ namespace Revenj.Extensibility.Autofac.Features.GeneratedFactories
 							.InstancePerLifetimeScope()
 							.ExternallyOwned()
 							.As(service)
-							.Targeting(r);
+							.Targeting(r)
+                            .InheritRegistrationOrderFrom(r);
 
 						return rb.CreateRegistration();
 					});

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -95,7 +95,8 @@ namespace Revenj.Extensibility.Autofac.Features.LazyDependencies
 			var rb = RegistrationBuilder.ForDelegate(
 				(c, p) => new Lazy<T>(() => (T)c.ResolveComponent(providedService, valueRegistration, p)))
 				.As(providedService)
-				.Targeting(valueRegistration);
+				.Targeting(valueRegistration)
+				.InheritRegistrationOrderFrom(valueRegistration);
 
 			return rb.CreateRegistration();
 		}

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
@@ -63,7 +63,8 @@ namespace Revenj.Extensibility.Autofac.Features.LightweightAdapters
 					{
 						var rb = RegistrationBuilder
 							.ForDelegate((c, p) => _activatorData.Adapter(c, p, c.ResolveComponent(service, r, Enumerable.Empty<Parameter>())))
-							.Targeting(r);
+							.Targeting(r)
+							.InheritRegistrationOrderFrom(r);
 
 						rb.RegistrationData.CopyFrom(_registrationData, true);
 

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -77,7 +77,8 @@ namespace Revenj.Extensibility.Autofac.Features.Metadata
 					(T)c.ResolveComponent(providedService, valueRegistration, p),
 					valueRegistration.Target.Metadata))
 				.As(providedService)
-				.Targeting(valueRegistration);
+				.Targeting(valueRegistration)
+				.InheritRegistrationOrderFrom(valueRegistration);
 
 			return rb.CreateRegistration();
 		}

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -76,7 +76,8 @@ namespace Revenj.Extensibility.Autofac.Features.OwnedInstances
 						})
 						.ExternallyOwned()
 						.As(service)
-						.Targeting(r);
+						.Targeting(r)
+						.InheritRegistrationOrderFrom(r);
 
 					return rb.CreateRegistration();
 				});

--- a/csharp/Core/Revenj.Core/Extensibility/Autofac/Util/SequenceGenerator.cs
+++ b/csharp/Core/Revenj.Core/Extensibility/Autofac/Util/SequenceGenerator.cs
@@ -1,0 +1,48 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2016 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Threading;
+
+namespace Revenj.Extensibility.Autofac.Util
+{
+	internal static class SequenceGenerator
+	{
+		private static long _lastSequence;
+
+		internal static long GetNextUniqueSequence()
+		{
+			while (true)
+			{
+				var last = Interlocked.Read(ref _lastSequence);
+				var next = DateTime.UtcNow.Ticks;
+				if (next <= last) next = last + 1;
+
+				var replaced = Interlocked.CompareExchange(ref _lastSequence, next, last);
+				if (replaced == last) return next;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi @zapov 

I had a look at https://github.com/ngs-doo/revenj/issues/162 and looks like it is because of Autofac service order, see https://github.com/aspnet/KestrelHttpServer/issues/923. 

This PR merged the changes from https://github.com/autofac/Autofac/commit/6c7f377d6bc279d62ee16f206690563a856e0313 and now Revenj starts in my .NET 5 Kestrel service.

Can you please check if these changes are acceptable or suggest otherwise?