### PR TITLE
Add offset to bar chart

### DIFF
--- a/typescript-react/src/components/Charts/Charts.tsx
+++ b/typescript-react/src/components/Charts/Charts.tsx
@@ -221,6 +221,7 @@ export class RichChart<T> extends React.PureComponent<IRichChart<T>> {
 
     const primaryYAxis = {
       id: PRIMARY_Y_AXIS_ID,
+      offset: ys[0]?.type === 'bar',
       stacked,
       ticks,
       position: 'left',
@@ -228,6 +229,7 @@ export class RichChart<T> extends React.PureComponent<IRichChart<T>> {
 
     const secondaryYAxis = {
       id: SECONDARY_Y_AXIS_ID,
+      offset: ys[1]?.type === 'bar',
       stacked,
       ticks,
       position: 'right',


### PR DESCRIPTION
Bar chart has offset defined as `true` by default to true but it was overridden here. Having it as `false` results in the column with the lowest value not displaying for graphs with relative values since it's value will be used as the starting point while rendering.