### PR TITLE
Add support for React-Boostrap button variants used in actions

### DIFF
--- a/typescript-react/src/components/Buttons/Buttons.tsx
+++ b/typescript-react/src/components/Buttons/Buttons.tsx
@@ -4,6 +4,7 @@ import Button from 'react-bootstrap/Button';
 
 import { isNullOrEmpty } from '../../util/StringUtils/StringUtils';
 import { NavigationContext } from '../Navigation/NavigationContext';
+import { ISimpleButtonAction } from '../Presenters/Actions';
 import { TooltipOnHover } from '../Tooltip/Tooltip';
 import { ButtonMenu } from './ButtonMenu';
 import { ButtonItem, isComponentButton } from './interfaces';
@@ -77,6 +78,7 @@ export class Buttons extends React.PureComponent<IButtons> {
             href={btn.url}
             onClick={btn.onClick}
             disabled={btn.disabled}
+            variant={(btn as ISimpleButtonAction).variant || 'primary'}
           >
             {btn.label}
           </Button>

--- a/typescript-react/src/components/Presenters/Actions.tsx
+++ b/typescript-react/src/components/Presenters/Actions.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import { ButtonVariant } from 'react-bootstrap/esm/types';
 
 import { ApiContext } from '../Api/ApiContext';
 import { Buttons } from '../Buttons/Buttons';
@@ -7,11 +8,12 @@ import { IComponentButtonProps } from '../Buttons/interfaces';
 import { ListPresenterComponent, UpdatePresenterContext } from '../Form/Context';
 import styles from './Presenter.module.css';
 
-interface ISimpleButtonAction {
+export interface ISimpleButtonAction {
   className?: string;
   disabled?: boolean;
   label: string;
   url?: string;
+  variant?: ButtonVariant;
   isVisible?: (actionsProps: IActions) => boolean;
   onClick?: (actionProps?: IActions) => void;
 }


### PR DESCRIPTION
React-Boostrap buttons have [variants](https://react-bootstrap.github.io/components/buttons/) that override other CSS.