### PR TITLE
Fix NumberFormatter if precision is set to 0

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.8.6"
+  "version": "1.8.7"
 }

--- a/typescript-react/src/util/Formatters/NumberFormatter.ts
+++ b/typescript-react/src/util/Formatters/NumberFormatter.ts
@@ -64,8 +64,7 @@ export const formatNumber = (number: any, pattern?: string): string => {
   });
 
   if (format) {
-    const precision = format && format.precision ? format.precision : undefined;
-    return new BigNumber(number).toFormat(precision);
+    return new BigNumber(number).toFormat(format?.precision);
   } else {
     return '';
   }


### PR DESCRIPTION
`format.precision ? format.precision : undefined` would return `undefined` since `0` resolves to `false`.