### PR TITLE
move validator funs to revenj

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -86,7 +86,7 @@
   "scripts": {
     "build": "microbundle-crl --no-compress --format modern,cjs",
     "deploy": "gh-pages -d example/build",
-    "prebuild": "npx ./scripts/postinstall.js",
+    "prebuild": "node ./scripts/postinstall.js",
     "predeploy": "cd example && yarn install && yarn run build",
     "prepare": "run-s build",
     "start": "microbundle-crl watch --no-compress --format modern,cjs",

--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.3"
+  "version": "1.9.4"
 }

--- a/typescript-react/src/components/Table/DetailRow/DetailRow.module.css
+++ b/typescript-react/src/components/Table/DetailRow/DetailRow.module.css
@@ -1,5 +1,6 @@
-@value mobileDetailBackground from '../Table.css';
+/* TODO: fix css loader to enable importing variables from css files on non-linux environment */
+
 
 .DetailRowWrapper {
-  background: mobileDetailBackground;
+  background: #F0F6F7;
 }

--- a/typescript-react/src/components/Table/Expander.module.css
+++ b/typescript-react/src/components/Table/Expander.module.css
@@ -1,7 +1,7 @@
-@value mobileExpanderColor from './Table.css';
+/* TODO: fix css loader to enable importing variables from css files on non-linux environment */
 
 .Expander {
-  color: mobileExpanderColor;
+  color: #D3D2D3;
   font-size: 14px;
   cursor: pointer;
 }

--- a/typescript-react/src/components/validation/index.ts
+++ b/typescript-react/src/components/validation/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {
   parseBigNum,
   Numeric,
@@ -14,6 +15,7 @@ import * as ordinal from './ordinal';
 import * as requireValidators from './required';
 import * as text from './text';
 import * as type from './type';
+import * as utils from './utils'
 import {
   validatorCreatorFactory as factory,
   withPreprocessor,
@@ -175,6 +177,9 @@ export const validateIf = <I, F, P>(predicate: IPredicate | boolean, validator: 
   };
 
 export const externalIDLength = maxLengthCreator(64);
+export const getBaseValue = utils.getBaseValue;
+export const valueIsAbsent = utils.valueIsAbsent;
+export const resolveRelativePath = utils.resolveRelativePath;
 
 export const zeroToHundredInterval = inIntervalCreator({ min: 0, max: 100 })
   ({ getValidatorErrorMessageOverride: 'Value has to be larger than 0 and smaller than 100' });

--- a/typescript-react/src/components/validation/index.ts
+++ b/typescript-react/src/components/validation/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import {
   parseBigNum,
   Numeric,

--- a/typescript-react/src/components/validation/utils.ts
+++ b/typescript-react/src/components/validation/utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable prettier/prettier */
+import { get } from '../../util/FunctionalUtils/FunctionalUtils';
+
 export const resolveRelativePath = <F>(relativePath: string, relativeTo: string): keyof F => {
   if (!relativePath.includes('/')) {
     return relativePath as keyof F;
@@ -20,3 +23,10 @@ export const resolveRelativePath = <F>(relativePath: string, relativeTo: string)
 
   return elements.join('.') as keyof F;
 };
+
+
+export const getBaseValue = <F>(right: any, otherRight: any) =>
+  (formValues: F, _: any, fieldName: string) => get(formValues, resolveRelativePath(right.path, fieldName) as keyof F) || get(formValues, resolveRelativePath(otherRight.path, fieldName) as keyof F);
+
+export const valueIsAbsent = (value: any) =>
+  (value == null) || (typeof value === 'string' && value === '');


### PR DESCRIPTION
- Use node instead of NPX to fix the installation in windows.
- Use colors directly in CSS till fix that. 
- add a new Utils file and add and export `getBaseValue `,`valueIsAbsent `, `resolveRelativePath`.
