### PR TITLE
Use SslStream because Mono is not .NET Core compatible

### DIFF
--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
@@ -91,16 +91,16 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 
 
 #if NETSTANDARD2_0
-        /// <summary>
-        /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
-        /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
-        /// </summary>
-        /// <remarks>
-        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
-        /// </remarks>
-        public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+		/// <summary>
+		/// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+		/// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
+		/// </summary>
+		/// <remarks>
+		/// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
+		/// </remarks>
+		public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
 #else
-        /// <summary>
+		/// <summary>
 		/// Mono.Security.Protocol.Tls.CertificateSelectionCallback delegate.
 		/// </summary>
 		public event CertificateSelectionCallback CertificateSelectionCallback;
@@ -513,11 +513,11 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 
 				connector.ProvideClientCertificatesCallback += ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-                connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
+				connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
 #else
-                connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
-                connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
-                connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
+				connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
+				connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
+				connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
 #endif
 
 				connector.Open();
@@ -607,7 +607,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				{
 					Connector.ProvideClientCertificatesCallback -= ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-                    Connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
+					Connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
 #else
 					Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
 					Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
@@ -802,7 +802,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		//
 
 #if !NETSTANDARD2_0
-        /// <summary>
+		/// <summary>
 		/// Default SSL CertificateSelectionCallback implementation.
 		/// </summary>
 		internal X509Certificate DefaultCertificateSelectionCallback(X509CertificateCollection clientCertificates,

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
@@ -99,7 +99,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
         /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
         /// </remarks>
         public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
-		#else
+#else
         /// <summary>
 		/// Mono.Security.Protocol.Tls.CertificateSelectionCallback delegate.
 		/// </summary>
@@ -514,7 +514,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				connector.ProvideClientCertificatesCallback += ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
                 connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
-				#else
+#else
                 connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
                 connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
                 connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
@@ -612,7 +612,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 					Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
 					Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
 					Connector.PrivateKeySelectionCallback -= PrivateKeySelectionCallbackDelegate;
-					#endif
+#endif
 
 					if (Connector.Transaction != null)
 					{

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnection.cs
@@ -34,7 +34,11 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Transactions;
+#if NETSTANDARD2_0
+using System.Net.Security;
+#else
 using Mono.Security.Protocol.Tls;
+#endif
 using IsolationLevel = System.Data.IsolationLevel;
 
 namespace Revenj.DatabasePersistence.Postgres.Npgsql
@@ -86,7 +90,17 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		internal ProvideClientCertificatesCallback ProvideClientCertificatesCallbackDelegate;
 
 
-		/// <summary>
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+        /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
+        /// </remarks>
+        public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+		#else
+        /// <summary>
 		/// Mono.Security.Protocol.Tls.CertificateSelectionCallback delegate.
 		/// </summary>
 		public event CertificateSelectionCallback CertificateSelectionCallback;
@@ -106,6 +120,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		public event PrivateKeySelectionCallback PrivateKeySelectionCallback;
 
 		internal PrivateKeySelectionCallback PrivateKeySelectionCallbackDelegate;
+#endif
 
 		// Set this when disposed is called.
 		private bool disposed = false;
@@ -154,9 +169,11 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			NotificationDelegate = new NotificationEventHandler(OnNotification);
 
 			ProvideClientCertificatesCallbackDelegate = new ProvideClientCertificatesCallback(DefaultProvideClientCertificatesCallback);
+#if !NETSTANDARD2_0
 			CertificateValidationCallbackDelegate = new CertificateValidationCallback(DefaultCertificateValidationCallback);
 			CertificateSelectionCallbackDelegate = new CertificateSelectionCallback(DefaultCertificateSelectionCallback);
 			PrivateKeySelectionCallbackDelegate = new PrivateKeySelectionCallback(DefaultPrivateKeySelectionCallback);
+#endif
 
 			// Fix authentication problems. See https://bugzilla.novell.com/show_bug.cgi?id=MONO77559 and 
 			// http://pgfoundry.org/forum/message.php?msg_id=1002377 for more info.
@@ -495,9 +512,13 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				connector = new NpgsqlConnector(this);
 
 				connector.ProvideClientCertificatesCallback += ProvideClientCertificatesCallbackDelegate;
-				connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
-				connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
-				connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
+#if NETSTANDARD2_0
+                connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
+				#else
+                connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
+                connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
+                connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
+#endif
 
 				connector.Open();
 			}
@@ -585,9 +606,13 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				else
 				{
 					Connector.ProvideClientCertificatesCallback -= ProvideClientCertificatesCallbackDelegate;
+#if NETSTANDARD2_0
+                    Connector.UserCertificateValidationCallback = UserCertificateValidationCallback;
+#else
 					Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
 					Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
 					Connector.PrivateKeySelectionCallback -= PrivateKeySelectionCallbackDelegate;
+					#endif
 
 					if (Connector.Transaction != null)
 					{
@@ -776,7 +801,8 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		// Event handlers
 		//
 
-		/// <summary>
+#if !NETSTANDARD2_0
+        /// <summary>
 		/// Default SSL CertificateSelectionCallback implementation.
 		/// </summary>
 		internal X509Certificate DefaultCertificateSelectionCallback(X509CertificateCollection clientCertificates,
@@ -822,6 +848,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				return null;
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Default SSL ProvideClientCertificatesCallback implementation.

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -358,7 +358,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			set { SetValue(GetKeyName(Keywords.IntegratedSecurity), value); }
 		}
 
-        #if NETSTANDARD2_0
+#if NETSTANDARD2_0
         private bool _trustServerCertificate;
 
         public bool TrustServerCertificate
@@ -459,7 +459,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 					return Keywords.Compatible;
 				case "APPLICATIONNAME":
 					return Keywords.ApplicationName;
-				#if NETSTANDARD2_0
+#if NETSTANDARD2_0
                 case "TRUSTSERVERCERTIFICATE":
                 case "TRUST SERVER CERTIFICATE":
                     return Keywords.TrustServerCertificate;
@@ -742,10 +742,10 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		IntegratedSecurity,
 		Compatible,
 		ApplicationName,
-		#if NETSTANDARD2_0
+#if NETSTANDARD2_0
         TrustServerCertificate,
         CheckCertificateRevocation,
-		#endif
+#endif
 	}
 
 	public enum SslMode

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -358,6 +358,24 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			set { SetValue(GetKeyName(Keywords.IntegratedSecurity), value); }
 		}
 
+        #if NETSTANDARD2_0
+        private bool _trustServerCertificate;
+
+        public bool TrustServerCertificate
+        {
+            get { return _trustServerCertificate; }
+            set { SetValue(GetKeyName(Keywords.TrustServerCertificate), value); }
+        }
+
+        private bool _checkCertificateRevocation;
+
+        public bool CheckCertificateRevocation
+        {
+            get { return _checkCertificateRevocation; }
+            set { SetValue(GetKeyName(Keywords.CheckCertificateRevocation), value); }
+        }
+#endif
+
 		private Version _compatible;
 		private static readonly Version THIS_VERSION = MethodBase.GetCurrentMethod().DeclaringType.Assembly.GetName().Version;
 		/// <summary>
@@ -441,6 +459,14 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 					return Keywords.Compatible;
 				case "APPLICATIONNAME":
 					return Keywords.ApplicationName;
+				#if NETSTANDARD2_0
+                case "TRUSTSERVERCERTIFICATE":
+                case "TRUST SERVER CERTIFICATE":
+                    return Keywords.TrustServerCertificate;
+                case "CHECKCERTIFICATEREVOCATION":
+                case "CHECK CERTIFICATE REVOCATION":
+                    return Keywords.CheckCertificateRevocation;
+#endif
 				default:
 					throw new ArgumentException("key=value argument incorrect in ConnectionString", key);
 			}
@@ -638,6 +664,14 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 					case Keywords.ApplicationName:
 						this._application_name = Convert.ToString(value);
 						break;
+#if NETSTANDARD2_0
+                    case Keywords.TrustServerCertificate:
+                        this._trustServerCertificate = ToBoolean(value);
+                        break;
+                    case Keywords.CheckCertificateRevocation:
+                        this._checkCertificateRevocation = ToBoolean(value);
+                        break;
+#endif
 				}
 			}
 			catch (InvalidCastException exception)
@@ -707,7 +741,11 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		UseExtendedTypes,
 		IntegratedSecurity,
 		Compatible,
-		ApplicationName
+		ApplicationName,
+		#if NETSTANDARD2_0
+        TrustServerCertificate,
+        CheckCertificateRevocation,
+		#endif
 	}
 
 	public enum SslMode

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -359,21 +359,21 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		}
 
 #if NETSTANDARD2_0
-        private bool _trustServerCertificate;
+		private bool _trustServerCertificate;
 
-        public bool TrustServerCertificate
-        {
-            get { return _trustServerCertificate; }
-            set { SetValue(GetKeyName(Keywords.TrustServerCertificate), value); }
-        }
+		public bool TrustServerCertificate
+		{
+			get { return _trustServerCertificate; }
+			set { SetValue(GetKeyName(Keywords.TrustServerCertificate), value); }
+		}
 
-        private bool _checkCertificateRevocation;
+		private bool _checkCertificateRevocation;
 
-        public bool CheckCertificateRevocation
-        {
-            get { return _checkCertificateRevocation; }
-            set { SetValue(GetKeyName(Keywords.CheckCertificateRevocation), value); }
-        }
+		public bool CheckCertificateRevocation
+		{
+			get { return _checkCertificateRevocation; }
+			set { SetValue(GetKeyName(Keywords.CheckCertificateRevocation), value); }
+		}
 #endif
 
 		private Version _compatible;
@@ -460,12 +460,12 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				case "APPLICATIONNAME":
 					return Keywords.ApplicationName;
 #if NETSTANDARD2_0
-                case "TRUSTSERVERCERTIFICATE":
-                case "TRUST SERVER CERTIFICATE":
-                    return Keywords.TrustServerCertificate;
-                case "CHECKCERTIFICATEREVOCATION":
-                case "CHECK CERTIFICATE REVOCATION":
-                    return Keywords.CheckCertificateRevocation;
+				case "TRUSTSERVERCERTIFICATE":
+				case "TRUST SERVER CERTIFICATE":
+					return Keywords.TrustServerCertificate;
+				case "CHECKCERTIFICATEREVOCATION":
+				case "CHECK CERTIFICATE REVOCATION":
+					return Keywords.CheckCertificateRevocation;
 #endif
 				default:
 					throw new ArgumentException("key=value argument incorrect in ConnectionString", key);
@@ -665,12 +665,12 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 						this._application_name = Convert.ToString(value);
 						break;
 #if NETSTANDARD2_0
-                    case Keywords.TrustServerCertificate:
-                        this._trustServerCertificate = ToBoolean(value);
-                        break;
-                    case Keywords.CheckCertificateRevocation:
-                        this._checkCertificateRevocation = ToBoolean(value);
-                        break;
+					case Keywords.TrustServerCertificate:
+						this._trustServerCertificate = ToBoolean(value);
+						break;
+					case Keywords.CheckCertificateRevocation:
+						this._checkCertificateRevocation = ToBoolean(value);
+						break;
 #endif
 				}
 			}
@@ -743,8 +743,8 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		Compatible,
 		ApplicationName,
 #if NETSTANDARD2_0
-        TrustServerCertificate,
-        CheckCertificateRevocation,
+		TrustServerCertificate,
+		CheckCertificateRevocation,
 #endif
 	}
 

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
@@ -93,7 +93,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		/// </summary>
 		internal event PrivateKeySelectionCallback PrivateKeySelectionCallback;
 
-        #else
+#else
         /// <summary>
         /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
         /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
@@ -102,7 +102,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
         /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
         /// </remarks>
         public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
-		#endif
+#endif
 
 		private ConnectionState _connection_state;
 
@@ -265,7 +265,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			get { return settings.IntegratedSecurity; }
 		}
 
-		#if NETSTANDARD2_0
+#if NETSTANDARD2_0
         internal Boolean TrustServerCertificate
         {
             get { return settings.TrustServerCertificate; }

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
@@ -78,7 +78,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		internal event ProvideClientCertificatesCallback ProvideClientCertificatesCallback;
 
 #if !NETSTANDARD2_0
-        /// <summary>
+		/// <summary>
 		/// Mono.Security.Protocol.Tls.CertificateSelectionCallback delegate.
 		/// </summary>
 		internal event CertificateSelectionCallback CertificateSelectionCallback;
@@ -94,14 +94,14 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		internal event PrivateKeySelectionCallback PrivateKeySelectionCallback;
 
 #else
-        /// <summary>
-        /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
-        /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
-        /// </summary>
-        /// <remarks>
-        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
-        /// </remarks>
-        public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+		/// <summary>
+		/// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+		/// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
+		/// </summary>
+		/// <remarks>
+		/// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
+		/// </remarks>
+		public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
 #endif
 
 		private ConnectionState _connection_state;
@@ -266,15 +266,15 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		}
 
 #if NETSTANDARD2_0
-        internal Boolean TrustServerCertificate
-        {
-            get { return settings.TrustServerCertificate; }
-        }
+		internal Boolean TrustServerCertificate
+		{
+			get { return settings.TrustServerCertificate; }
+		}
 
-        internal Boolean CheckCertificateRevocation
-        {
-            get { return settings.CheckCertificateRevocation; }
-        }
+		internal Boolean CheckCertificateRevocation
+		{
+			get { return settings.CheckCertificateRevocation; }
+		}
 #endif
 
 		/// <summary>

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnector.cs
@@ -36,7 +36,11 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
+#if NETSTANDARD2_0
+using System.Net.Security;
+#else
 using Mono.Security.Protocol.Tls;
+#endif
 using Revenj.DatabasePersistence.Postgres.NpgsqlTypes;
 
 namespace Revenj.DatabasePersistence.Postgres.Npgsql
@@ -73,7 +77,8 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		/// </summary>
 		internal event ProvideClientCertificatesCallback ProvideClientCertificatesCallback;
 
-		/// <summary>
+#if !NETSTANDARD2_0
+        /// <summary>
 		/// Mono.Security.Protocol.Tls.CertificateSelectionCallback delegate.
 		/// </summary>
 		internal event CertificateSelectionCallback CertificateSelectionCallback;
@@ -87,6 +92,17 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		/// Mono.Security.Protocol.Tls.PrivateKeySelectionCallback delegate.
 		/// </summary>
 		internal event PrivateKeySelectionCallback PrivateKeySelectionCallback;
+
+        #else
+        /// <summary>
+        /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+        /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
+        /// </remarks>
+        public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+		#endif
 
 		private ConnectionState _connection_state;
 
@@ -248,6 +264,18 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		{
 			get { return settings.IntegratedSecurity; }
 		}
+
+		#if NETSTANDARD2_0
+        internal Boolean TrustServerCertificate
+        {
+            get { return settings.TrustServerCertificate; }
+        }
+
+        internal Boolean CheckCertificateRevocation
+        {
+            get { return settings.CheckCertificateRevocation; }
+        }
+#endif
 
 		/// <summary>
 		/// Gets the current state of the connection.
@@ -485,6 +513,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			}
 		}
 
+#if !NETSTANDARD2_0
 		/// <summary>
 		/// Default SSL CertificateSelectionCallback implementation.
 		/// </summary>
@@ -531,6 +560,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				return null;
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Default SSL ProvideClientCertificatesCallback implementation.

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
@@ -377,9 +377,13 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			if (Connector != null)
 			{
 				Connector.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
+#if NETSTANDARD2_0
+                Connector.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
+#else
 				Connector.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 				Connector.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
 				Connector.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
+				#endif
 
 				try
 				{
@@ -404,16 +408,24 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 							NpgsqlConnector Spare = new NpgsqlConnector(Connection);
 
 							Spare.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
+#if NETSTANDARD2_0
+                            Spare.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
+#else
 							Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 							Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
 							Spare.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
+							#endif
 
 							Spare.Open();
 
 							Spare.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
-							Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
-							Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
-							Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+#if NETSTANDARD2_0
+                            Spare.UserCertificateValidationCallback = null;
+#else
+                            Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
+                            Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
+                            Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+							#endif
 
 							Queue.EnqueueAvailable(Spare);
 						}
@@ -458,9 +470,13 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			}
 
 			Connector.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
+#if NETSTANDARD2_0
+            Connector.UserCertificateValidationCallback = null;
+#else
 			Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
 			Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
 			Connector.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+			#endif
 
 			bool inQueue = queue.RemoveBusy(Connector);
 

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
@@ -383,7 +383,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 				Connector.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 				Connector.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
 				Connector.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
-				#endif
+#endif
 
 				try
 				{
@@ -414,7 +414,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 							Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 							Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
 							Spare.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
-							#endif
+#endif
 
 							Spare.Open();
 
@@ -425,7 +425,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
                             Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
                             Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
                             Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
-							#endif
+#endif
 
 							Queue.EnqueueAvailable(Spare);
 						}
@@ -476,7 +476,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
 			Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
 			Connector.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
-			#endif
+#endif
 
 			bool inQueue = queue.RemoveBusy(Connector);
 

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/NpgsqlConnectorPool.cs
@@ -378,7 +378,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			{
 				Connector.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-                Connector.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
+				Connector.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
 #else
 				Connector.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 				Connector.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
@@ -409,7 +409,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 
 							Spare.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-                            Spare.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
+							Spare.UserCertificateValidationCallback = Connection.UserCertificateValidationCallback;
 #else
 							Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
 							Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
@@ -420,11 +420,11 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 
 							Spare.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-                            Spare.UserCertificateValidationCallback = null;
+							Spare.UserCertificateValidationCallback = null;
 #else
-                            Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
-                            Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
-                            Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+							Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
+							Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
+							Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
 #endif
 
 							Queue.EnqueueAvailable(Spare);
@@ -471,7 +471,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 
 			Connector.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
 #if NETSTANDARD2_0
-            Connector.UserCertificateValidationCallback = null;
+			Connector.UserCertificateValidationCallback = null;
 #else
 			Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
 			Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlClosedState.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlClosedState.cs
@@ -89,10 +89,10 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 			return Dns.GetHostAddresses(HostName);
 		}
 
-		#if NETSTANDARD2_0
+#if NETSTANDARD2_0
         private static bool DefaultUserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
             => sslPolicyErrors == SslPolicyErrors.None;
-		#endif
+#endif
 
 		public override void Open(NpgsqlConnector context)
 		{

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlClosedState.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlClosedState.cs
@@ -90,8 +90,8 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 		}
 
 #if NETSTANDARD2_0
-        private static bool DefaultUserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-            => sslPolicyErrors == SslPolicyErrors.None;
+		private static bool DefaultUserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+			=> sslPolicyErrors == SslPolicyErrors.None;
 #endif
 
 		public override void Open(NpgsqlConnector context)
@@ -152,33 +152,33 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 						context.DefaultProvideClientCertificatesCallback(clientCertificates);
 
 #if NETSTANDARD2_0
-                        RemoteCertificateValidationCallback certificateValidationCallback;
-                        if (context.TrustServerCertificate)
-                            certificateValidationCallback = (sender, certificate, chain, errors) => true;
-                        else if (context.UserCertificateValidationCallback != null)
-                            certificateValidationCallback = context.UserCertificateValidationCallback;
-                        else
-                            certificateValidationCallback = DefaultUserCertificateValidationCallback;
+						RemoteCertificateValidationCallback certificateValidationCallback;
+						if (context.TrustServerCertificate)
+							certificateValidationCallback = (sender, certificate, chain, errors) => true;
+						else if (context.UserCertificateValidationCallback != null)
+							certificateValidationCallback = context.UserCertificateValidationCallback;
+						else
+							certificateValidationCallback = DefaultUserCertificateValidationCallback;
 
 						var sslStream = new SslStream(stream, false, certificateValidationCallback);
-                        sslStream.AuthenticateAsClient(context.Host, clientCertificates, 
-                            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, 
-                            context.CheckCertificateRevocation);
-                        stream = sslStream;
+						sslStream.AuthenticateAsClient(context.Host, clientCertificates, 
+							SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, 
+							context.CheckCertificateRevocation);
+						stream = sslStream;
 #else
-                        stream = new SslClientStream(
-                            stream,
-                            context.Host,
-                            true,
-                            SecurityProtocolType.Default,
-                            clientCertificates);
+						stream = new SslClientStream(
+							stream,
+							context.Host,
+							true,
+							SecurityProtocolType.Default,
+							clientCertificates);
 
-                        ((SslClientStream)stream).ClientCertSelectionDelegate =
-                            new CertificateSelectionCallback(context.DefaultCertificateSelectionCallback);
-                        ((SslClientStream)stream).ServerCertValidationDelegate =
-                            new CertificateValidationCallback(context.DefaultCertificateValidationCallback);
-                        ((SslClientStream)stream).PrivateKeyCertSelectionDelegate =
-                            new PrivateKeySelectionCallback(context.DefaultPrivateKeySelectionCallback);
+						((SslClientStream)stream).ClientCertSelectionDelegate =
+							new CertificateSelectionCallback(context.DefaultCertificateSelectionCallback);
+						((SslClientStream)stream).ServerCertValidationDelegate =
+							new CertificateValidationCallback(context.DefaultCertificateValidationCallback);
+						((SslClientStream)stream).PrivateKeyCertSelectionDelegate =
+							new PrivateKeySelectionCallback(context.DefaultPrivateKeySelectionCallback);
 
 #endif
 					}


### PR DESCRIPTION
For .NET Standard, use System.Net.Security.SslStream rather than Mono.Security.Protocol.Tls.SslClientStream because Mono.Security is not .NET Core compatible.