### PR TITLE
Use SCRAM-SHA-256 with SSL (SCRAM-SHA-256-PLUS not supported yet)

### DIFF
--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
@@ -640,7 +640,7 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 									var saslAuthMechanism = PGUtil.ReadString(stream, queue);
 									if (saslAuthMechanism == "SCRAM-SHA-256-PLUS")
 										saslAuthMechanism = PGUtil.ReadString(stream, queue);
-                                    if (saslAuthMechanism == "SCRAM-SHA-256")
+									if (saslAuthMechanism == "SCRAM-SHA-256")
 									{
 										stream.ReadByte();
 										scram = new SCRAM(saslAuthMechanism, context.UserName);

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
@@ -638,7 +638,9 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 #endif
 								case AuthenticationRequestType.AuthenticationSASL:
 									var saslAuthMechanism = PGUtil.ReadString(stream, queue);
-									if (saslAuthMechanism == "SCRAM-SHA-256")
+                                    if (saslAuthMechanism == "SCRAM-SHA-256-PLUS")
+                                        saslAuthMechanism = PGUtil.ReadString(stream, queue);
+                                    if (saslAuthMechanism == "SCRAM-SHA-256")
 									{
 										stream.ReadByte();
 										scram = new SCRAM(saslAuthMechanism, context.UserName);

--- a/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
+++ b/csharp/Core/Revenj.Core/DatabasePersistence/Postgres/Npgsql/State/NpgsqlState.cs
@@ -638,8 +638,8 @@ namespace Revenj.DatabasePersistence.Postgres.Npgsql
 #endif
 								case AuthenticationRequestType.AuthenticationSASL:
 									var saslAuthMechanism = PGUtil.ReadString(stream, queue);
-                                    if (saslAuthMechanism == "SCRAM-SHA-256-PLUS")
-                                        saslAuthMechanism = PGUtil.ReadString(stream, queue);
+									if (saslAuthMechanism == "SCRAM-SHA-256-PLUS")
+										saslAuthMechanism = PGUtil.ReadString(stream, queue);
                                     if (saslAuthMechanism == "SCRAM-SHA-256")
 									{
 										stream.ReadByte();


### PR DESCRIPTION
SCRAM supported was added in https://github.com/ngs-doo/revenj/commit/31ace1d466722b246d6da890816fac8af9e94dd6 but it throws an exception when also using SSL:
```
Revenj.DatabasePersistence.Postgres.Npgsql.NpgsqlException:
Only Scram SHA 256 is supported
   at Revenj.DatabasePersistence.Postgres.Npgsql.NpgsqlState.ProcessBackendResponses_Ver_3(NpgsqlConnector context)+MoveNext() 
in csharp\Core\Revenj.Core\DatabasePersistence\Postgres\Npgsql\State\NpgsqlState.cs:line 658
```

SCRAM-SHA-256-PLUS was implemented in [Npgsql PR 3111](https://github.com/npgsql/npgsql/pull/3111/files) and I tried to back port but was blocked by Npgsql using `System.Net.Security.SslStream` and Revenj's using `Revenj.DatabasePersistence.Postgres.Npgsql.NpgsqlBufferedStream`

I've noticed that if the client does not support SCRAM-SHA-256-PLUS channel binding, the client can continue to use SCRAM-SHA-256: [NpgsqlConnector.Auth.cs#L139](https://github.com/npgsql/npgsql/blob/af17de802bde4a3f8ac09195861ae32eeb725900/src/Npgsql/Internal/NpgsqlConnector.Auth.cs#L139)

I found reading the next stream string after `SCRAM-SHA-256-PLUS` returns `SCRAM-SHA-256` and setting then `saslAuthMechanism` works as usual. I've tested the change on SSL and non-SSL configurations.