### PR TITLE
Implement IHostBuilder support

### DIFF
--- a/csharp/Server/Revenj.AspNetCore/RevenjWebHostBuilderExtension.cs
+++ b/csharp/Server/Revenj.AspNetCore/RevenjWebHostBuilderExtension.cs
@@ -1,10 +1,16 @@
-﻿using Revenj.AspNetCore;
+﻿using Microsoft.Extensions.Hosting;
+using Revenj.AspNetCore;
 
 namespace Microsoft.AspNetCore.Hosting
 {
 	public static class RevenjWebHostBuilderExtension
 	{
 		public static IRevenjConfig UseRevenj(this IWebHostBuilder builder)
+		{
+			return new RevenjConfig(builder);
+		}
+
+		public static IRevenjConfig UseRevenj(this IHostBuilder builder)
 		{
 			return new RevenjConfig(builder);
 		}


### PR DESCRIPTION
Hi @zapov , hope you are doing well. Happy New Year!

This PR adds support for IHostBuilder. Revenj currently supports IWebHostBuilder.

As we upgraded our projects to .NET 8 and the latest NuGets, we noticed IWebHostBuilder.UseSerilog() was deprecated in Serilog v5.0.0 and [removed](https://github.com/serilog/serilog-aspnetcore/pull/338/files#diff-78851308a284bcd2f55cb4b79b556d6148801c57bd8c3d492684f417eef00a1f) in Serilog v8.0.0

I tried
```csharp
public static IHostBuilder CreateHostBuilder(string[] args)
{
    return Host.CreateDefaultBuilder(args)
        .ConfigureWebHostDefaults(webBuilder =>
        {
             webBuilder.UseRevenj()
                 .UseRevenjServiceProvider()
                 .Configure("...");
                    
```
but got this exception
```
System.NotSupportedException: Requested type not found in services: Revenj.Extensibility.IObjectFactory
    Use GetService API to avoid this exception and get null value instead.
    Check if service should be registered or it's dependencies satisfied
at Revenj.DomainPatterns.ServiceProviderHelper.Resolve[T](IServiceProvider provider) in Revenj.Core.Interface\DomainPatterns\ServiceLocator.cs:line 22

```

Hosting changed in ASP.NET Core 3.0 and requires a different integration. You can no longer return IServiceProvider from ConfigureServices, nor can you add your service provider factory to the service collection.
`UseServiceProviderFactory` is now used, as per https://autofac.readthedocs.io/en/latest/integration/aspnetcore.html#asp-net-core-3-0-and-generic-hosting

Working examples:
https://github.com/Kobus-Smit/revenj-examples/tree/master/net6.0-IWebHostBuilder/Program.cs
https://github.com/Kobus-Smit/revenj-examples/tree/master/net6.0-IHostBuilder/Program.cs
https://github.com/Kobus-Smit/revenj-examples/tree/master/net6.0-IWebApplicationBuilder/Program.cs
