### PR TITLE
Fix serialization of Long values over MAX_SAFE_INTEGER

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -93,8 +93,9 @@
     "test": "run-s test:unit test:lint",
     "test:lint": "eslint .",
     "test:unit": "cross-env CI=1 react-scripts test --env=jsdom",
+    "test:update":"react-scripts test -u --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.17"
+  "version": "1.9.18"
 }

--- a/typescript-react/src/constants.ts
+++ b/typescript-react/src/constants.ts
@@ -1,4 +1,6 @@
 export const INT_MAX_VALUE = 2147483647;
 export const INT_MIN_VALUE = -2147483648;
+export const LONG_MAX_VALUE = '9223372036854775807';
+export const LONG_MIN_VALUE = '-9223372036854775808';
 export const SHORT_MAX_VALUE = 32767;
 export const SHORT_MIN_VALUE = -32768;

--- a/typescript-react/src/marshalling/__tests__/__snapshots__/assert.spec.ts.snap
+++ b/typescript-react/src/marshalling/__tests__/__snapshots__/assert.spec.ts.snap
@@ -22,11 +22,23 @@ exports[`data marshalling asserting assertInt should explode on non-integers 4`]
 
 exports[`data marshalling asserting assertInt should explode on non-integers 5`] = `"Expected an Int, but value is 2147483648"`;
 
+exports[`data marshalling asserting assertLong should assert valid Long range 1`] = `"Expected a Long, but value is -9223372036854775809"`;
+
+exports[`data marshalling asserting assertLong should assert valid Long range 2`] = `"Expected a Long, but value is 9223372036854775808"`;
+
 exports[`data marshalling asserting assertLong should explode on non-longs 1`] = `"Expected a Long, but value is bla"`;
 
 exports[`data marshalling asserting assertLong should explode on non-longs 2`] = `"Expected a Long, but value is null"`;
 
 exports[`data marshalling asserting assertLong should explode on non-longs 3`] = `"Expected a Long, but value is 1.55"`;
+
+exports[`data marshalling asserting assertLong should explode on non-longs 4`] = `"Expected a Long, but value is 1.7976931348623157e+308"`;
+
+exports[`data marshalling asserting assertLong should explode on non-longs 5`] = `"Expected a Long, but value is 5e-324"`;
+
+exports[`data marshalling asserting assertLong should explode on non-longs 6`] = `"Expected a Long, but value is Infinity"`;
+
+exports[`data marshalling asserting assertLong should explode on non-longs 7`] = `"Expected a Long, but value is -Infinity"`;
 
 exports[`data marshalling asserting assertPresence should raise an error if the value is not present, but required 1`] = `"Value is required, but is not set!"`;
 

--- a/typescript-react/src/marshalling/__tests__/assert.spec.ts
+++ b/typescript-react/src/marshalling/__tests__/assert.spec.ts
@@ -1,6 +1,8 @@
 import {
   INT_MAX_VALUE,
   INT_MIN_VALUE,
+  LONG_MAX_VALUE,
+  LONG_MIN_VALUE,
 } from '../../constants';
 import {
   ColumnType,
@@ -11,6 +13,7 @@ import {
   SHORT_MIN_VALUE,
 } from '../../constants';
 import * as Assert from '../assert';
+import { parseBigNum } from '../../util/NumberUtils/NumberUtils';
 
 describe('data marshalling asserting', () => {
   describe('assertPresence', () => {
@@ -88,20 +91,52 @@ ing`];
 
   describe('assertLong', () => {
     it('should pass through valid longs', () => {
-      const valids = [-10, 0, 235] as Long[];
+      const valids = [
+        '-10',
+        '0',
+        '235',
+        '-1',
+        '1',
+        '-9007199254740995',
+        '-9007199254740999',
+        '9007199254740995',
+        '9007199254740999',
+        Number.MIN_SAFE_INTEGER.toString(),
+        Number.MAX_SAFE_INTEGER.toString(),
+        LONG_MAX_VALUE.toString(),
+        LONG_MIN_VALUE.toString(),
+      ] as Long[];
       for (const valid of valids) {
         expect(Assert.assertLong(valid)).toBe(valid);
       }
     });
 
     it('should explode on non-longs', () => {
-      const invalids = ['bla', null, 1.55] as any[];
+      const invalids = [
+        'bla',
+        null,
+        1.55,
+        Number.MAX_VALUE,
+        Number.MIN_VALUE,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ] as any[];
       for (const invalid of invalids) {
         expect(() => Assert.assertLong(invalid)).toThrowErrorMatchingSnapshot();
       }
     });
 
-    it.skip('should assert valid Long range', () => { return; }); // TODO: Some nice day
+    it('should assert valid Long range', () => {
+      const minValid = LONG_MIN_VALUE.toString();
+      const maxValud = LONG_MAX_VALUE.toString();
+      expect(Assert.assertLong(minValid)).toBe(minValid);
+      expect(Assert.assertLong(maxValud)).toBe(maxValud);
+
+      const bellowMin = parseBigNum(LONG_MIN_VALUE).minus(1).toString();
+      const aboveMax = parseBigNum(LONG_MAX_VALUE).plus(1).toString();
+      expect(() => Assert.assertLong(bellowMin)).toThrowErrorMatchingSnapshot();
+      expect(() => Assert.assertLong(aboveMax)).toThrowErrorMatchingSnapshot();
+    });
   });
 
   describe('assertShort', () => {
@@ -374,7 +409,7 @@ ing`];
       const s3 = {
         bucket: 'test',
         key: '58d33650-1f54-4190-b9f6-f85d0b889350',
-        length: 1024 as Long,
+        length: '1024',
         metadata: {
           type: 'personal document',
         },

--- a/typescript-react/src/marshalling/__tests__/boot.spec.ts
+++ b/typescript-react/src/marshalling/__tests__/boot.spec.ts
@@ -14,7 +14,7 @@ describe('Instafin marshalling', () => {
 
   it('should deserialize simple types', () => {
     expect(marshaller.deserialize(10, 'Int', true, 'test')).toEqual(10);
-    expect(marshaller.deserialize(10, 'Long', true, 'test')).toEqual(10);
+    expect(marshaller.deserialize(10, 'Long', true, 'test')).toEqual('10');
     expect(marshaller.deserialize(10.5, 'Double', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize(10.5, 'Float', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize('10.5', 'Decimal', true, 'test')).toEqual('10.5');
@@ -26,7 +26,7 @@ describe('Instafin marshalling', () => {
 
   it('should serialize simple types', () => {
     expect(marshaller.serialize(10, 'Int', true, 'test')).toEqual(10);
-    expect(marshaller.serialize(10, 'Long', true, 'test')).toEqual(10);
+    expect(marshaller.serialize(10, 'Long', true, 'test')).toEqual('10');
     expect(marshaller.serialize(10.5, 'Double', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize(10.5, 'Float', true, 'test')).toEqual(10.5);
     expect(marshaller.serialize('10.5', 'Decimal', true, 'test')).toEqual('10.5');
@@ -62,7 +62,7 @@ describe('Instafin marshalling', () => {
 
   it('should default to 0 when serializing non-nullable numbers', () => {
     expect(marshaller.serialize(undefined, 'Int', true, 'test')).toEqual(0);
-    expect(marshaller.serialize(undefined, 'Long', true, 'test')).toEqual(0);
+    expect(marshaller.serialize(undefined, 'Long', true, 'test')).toEqual('0');
     expect(marshaller.serialize(undefined, 'Double', true, 'test')).toEqual(0);
     expect(marshaller.serialize(undefined, 'Float', true, 'test')).toEqual(0);
     expect(marshaller.serialize(undefined, 'Decimal', true, 'test')).toEqual('0');
@@ -71,7 +71,7 @@ describe('Instafin marshalling', () => {
 
   it('should default to 0 when deserializing non-nullable numbers', () => {
     expect(marshaller.deserialize(undefined, 'Int', true, 'test')).toEqual(0);
-    expect(marshaller.deserialize(undefined, 'Long', true, 'test')).toEqual(0);
+    expect(marshaller.deserialize(undefined, 'Long', true, 'test')).toEqual('0');
     expect(marshaller.deserialize(undefined, 'Double', true, 'test')).toEqual(0);
     expect(marshaller.deserialize(undefined, 'Float', true, 'test')).toEqual(0);
     expect(marshaller.deserialize(undefined, 'Decimal', true, 'test')).toEqual('0');

--- a/typescript-react/src/marshalling/boot.ts
+++ b/typescript-react/src/marshalling/boot.ts
@@ -82,11 +82,11 @@ export const initialize = ({ before, after }: IBootConfig) => {
     // Number unpacking from string fields
     .registerSerializerMiddleware(
       (it: string) => Number.parseInt(it, 10),
-      (it, typeName) => it != null && typeof it === 'string' && ['Int', 'Long', 'Short'].includes(typeName),
+      (it, typeName) => it != null && typeof it === 'string' && ['Int', 'Short'].includes(typeName),
     )
     .registerSerializerMiddleware(
       (it: string) => Number.parseFloat(it),
-      (it, typeName) => it != null && typeof it === 'string' && ['Long', 'Double'].includes(typeName),
+      (it, typeName) => it != null && typeof it === 'string' && ['Float', 'Double'].includes(typeName),
     )
     // Flatten optional empty strings into nothing on serialize
     .registerSerializerMiddleware(
@@ -106,7 +106,12 @@ export const initialize = ({ before, after }: IBootConfig) => {
     // Ensure required missing short/int/long/decimal/double fields are set to 0 (BE omits false to save up on cube config payloads)
     .registerDeserializerMiddleware(
       () => 0,
-      (it, typeName, isNonNullable) => it == null && isNonNullable && ['long', 'int', 'short', 'decimal', 'double', 'float', 'money'].includes(typeName.toLocaleLowerCase()),
+      (it, typeName, isNonNullable) => it == null && isNonNullable && ['int', 'short', 'decimal', 'double', 'float', 'money'].includes(typeName.toLocaleLowerCase()),
+      MiddlewareStep.Before,
+    )
+    .registerDeserializerMiddleware(
+      () => '0',
+      (it, typeName, isNonNullable) => it == null && isNonNullable && ['long'].includes(typeName.toLocaleLowerCase()),
       MiddlewareStep.Before,
     )
     // Ensure optional missing short/int/long/decimal/double fields are set to undefined (BE omits false to save up on cube config payloads)

--- a/typescript-react/src/types/global.d.ts
+++ b/typescript-react/src/types/global.d.ts
@@ -11,7 +11,7 @@ declare interface INumberFormatter {
 // Custom branded types
 declare type DateStr = string & { __DateStrBrand__: void };
 declare type TimestampStr = string & { __TimestampStrBrand__: void };
-declare type Long = number & { __LongBrand__: void };
+declare type Long = string & { __LongBrand__: void };
 declare type Int = number & { __IntBrand__: void };
 declare type Short = number & { __ShortBrand__: void };
 declare type Double = number & { __DoubleBrand__: void };


### PR DESCRIPTION
JavaScript's Number.MAX_SAFE_INTEGER is 2^53 - 1, but other sane languages use 64-bit integers (2^64). This caused issues when parsing large Long values, leading to precision loss in the frontend. To fix this, Long values are now serialized as strings.