### PR TITLE
Serialize safe integers as numbers, else strings

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.18"
+  "version": "1.9.19"
 }

--- a/typescript-react/src/marshalling/__tests__/assert.spec.ts
+++ b/typescript-react/src/marshalling/__tests__/assert.spec.ts
@@ -92,17 +92,17 @@ ing`];
   describe('assertLong', () => {
     it('should pass through valid longs', () => {
       const valids = [
-        '-10',
-        '0',
-        '235',
-        '-1',
-        '1',
+        -10,
+        0,
+        235,
+        -1,
+        1,
         '-9007199254740995',
         '-9007199254740999',
         '9007199254740995',
         '9007199254740999',
-        Number.MIN_SAFE_INTEGER.toString(),
-        Number.MAX_SAFE_INTEGER.toString(),
+        Number.MIN_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
         LONG_MAX_VALUE.toString(),
         LONG_MIN_VALUE.toString(),
       ] as Long[];
@@ -409,7 +409,7 @@ ing`];
       const s3 = {
         bucket: 'test',
         key: '58d33650-1f54-4190-b9f6-f85d0b889350',
-        length: '1024',
+        length: 1024,
         metadata: {
           type: 'personal document',
         },

--- a/typescript-react/src/marshalling/__tests__/boot.spec.ts
+++ b/typescript-react/src/marshalling/__tests__/boot.spec.ts
@@ -14,7 +14,8 @@ describe('Instafin marshalling', () => {
 
   it('should deserialize simple types', () => {
     expect(marshaller.deserialize(10, 'Int', true, 'test')).toEqual(10);
-    expect(marshaller.deserialize(10, 'Long', true, 'test')).toEqual('10');
+    expect(marshaller.deserialize(10, 'Long', true, 'test')).toEqual(10);
+    expect(marshaller.serialize('9007199254740995', 'Long', true, 'test')).toEqual('9007199254740995');
     expect(marshaller.deserialize(10.5, 'Double', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize(10.5, 'Float', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize('10.5', 'Decimal', true, 'test')).toEqual('10.5');
@@ -26,7 +27,8 @@ describe('Instafin marshalling', () => {
 
   it('should serialize simple types', () => {
     expect(marshaller.serialize(10, 'Int', true, 'test')).toEqual(10);
-    expect(marshaller.serialize(10, 'Long', true, 'test')).toEqual('10');
+    expect(marshaller.serialize(10, 'Long', true, 'test')).toEqual(10);
+    expect(marshaller.serialize('9007199254740995', 'Long', true, 'test')).toEqual('9007199254740995');
     expect(marshaller.serialize(10.5, 'Double', true, 'test')).toEqual(10.5);
     expect(marshaller.deserialize(10.5, 'Float', true, 'test')).toEqual(10.5);
     expect(marshaller.serialize('10.5', 'Decimal', true, 'test')).toEqual('10.5');
@@ -62,7 +64,7 @@ describe('Instafin marshalling', () => {
 
   it('should default to 0 when serializing non-nullable numbers', () => {
     expect(marshaller.serialize(undefined, 'Int', true, 'test')).toEqual(0);
-    expect(marshaller.serialize(undefined, 'Long', true, 'test')).toEqual('0');
+    expect(marshaller.serialize(undefined, 'Long', true, 'test')).toEqual(0);
     expect(marshaller.serialize(undefined, 'Double', true, 'test')).toEqual(0);
     expect(marshaller.serialize(undefined, 'Float', true, 'test')).toEqual(0);
     expect(marshaller.serialize(undefined, 'Decimal', true, 'test')).toEqual('0');
@@ -71,7 +73,7 @@ describe('Instafin marshalling', () => {
 
   it('should default to 0 when deserializing non-nullable numbers', () => {
     expect(marshaller.deserialize(undefined, 'Int', true, 'test')).toEqual(0);
-    expect(marshaller.deserialize(undefined, 'Long', true, 'test')).toEqual('0');
+    expect(marshaller.deserialize(undefined, 'Long', true, 'test')).toEqual(0);
     expect(marshaller.deserialize(undefined, 'Double', true, 'test')).toEqual(0);
     expect(marshaller.deserialize(undefined, 'Float', true, 'test')).toEqual(0);
     expect(marshaller.deserialize(undefined, 'Decimal', true, 'test')).toEqual('0');

--- a/typescript-react/src/marshalling/assert.ts
+++ b/typescript-react/src/marshalling/assert.ts
@@ -70,6 +70,9 @@ export const assertLong = <T extends Long>(value: T): T => {
     if (number < BigInt(LONG_MIN_VALUE) || number > BigInt(LONG_MAX_VALUE)) {
       throw new Error(`Expected a Long, but value is ${value}`);
     }
+    if (number >= Number.MIN_SAFE_INTEGER && number <= Number.MAX_SAFE_INTEGER) {
+      return Number.parseInt(String(value), 10) as T;
+    }
     return number.toString() as unknown as T;
   } catch (error) {
     throw new Error(`Expected a Long, but value is ${value}`);

--- a/typescript-react/src/marshalling/boot.ts
+++ b/typescript-react/src/marshalling/boot.ts
@@ -106,12 +106,7 @@ export const initialize = ({ before, after }: IBootConfig) => {
     // Ensure required missing short/int/long/decimal/double fields are set to 0 (BE omits false to save up on cube config payloads)
     .registerDeserializerMiddleware(
       () => 0,
-      (it, typeName, isNonNullable) => it == null && isNonNullable && ['int', 'short', 'decimal', 'double', 'float', 'money'].includes(typeName.toLocaleLowerCase()),
-      MiddlewareStep.Before,
-    )
-    .registerDeserializerMiddleware(
-      () => '0',
-      (it, typeName, isNonNullable) => it == null && isNonNullable && ['long'].includes(typeName.toLocaleLowerCase()),
+      (it, typeName, isNonNullable) => it == null && isNonNullable && ['long', 'int', 'short', 'decimal', 'double', 'float', 'money'].includes(typeName.toLocaleLowerCase()),
       MiddlewareStep.Before,
     )
     // Ensure optional missing short/int/long/decimal/double fields are set to undefined (BE omits false to save up on cube config payloads)


### PR DESCRIPTION
Updates the long serialization logic to distinguish between values inside and outside JavaScript's safe integer range:
- Values within Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER are now serialized as plain numbers.
- Values outside this range are serialized as strings to preserve precision.