### PR TITLE
Bump is-plain-object

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-standard": "^4.0.1",
     "gh-pages": "^6.0.0",
-    "is-plain-object": "^2.0.4",
+    "is-plain-object": "^5.0.0",
     "microbundle-crl": "^0.13.10",
     "moment": "^2.29.4",
     "moment-timezone": "oradian/moment-timezone",
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.19"
+  "version": "1.9.20"
 }

--- a/typescript-react/src/util/FunctionalUtils/FunctionalUtils.ts
+++ b/typescript-react/src/util/FunctionalUtils/FunctionalUtils.ts
@@ -1,5 +1,5 @@
 import fastDeepEqual from 'fast-deep-equal';
-import isPlainObject from 'is-plain-object';
+import { isPlainObject } from 'is-plain-object';
 
 export const mapOrElse = (
   value: any,

--- a/typescript-react/src/util/FunctionalUtils/__tests__/FunctionalUtils.spec.ts
+++ b/typescript-react/src/util/FunctionalUtils/__tests__/FunctionalUtils.spec.ts
@@ -1,4 +1,5 @@
 // tslint:disable:rule no-construct
+import BigNumber from 'bignumber.js';
 import {
   concatUnique,
   deduplicateBy,
@@ -19,6 +20,7 @@ import {
   squashObject,
   takeWhile,
   valueOrNull,
+  isObject,
 } from '../FunctionalUtils';
 
 interface IThing {
@@ -675,6 +677,57 @@ describe('functional.ts', () => {
       expect(flattenName(null)).toEqual('');
       expect(flattenName(undefined)).toEqual('');
       expect(flattenName([undefined, 'value', null, '', ' '])).toEqual('value');
+    });
+  });
+
+  describe('isObject', () => {
+    it('should return true for plain objects', () => {
+      expect(isObject({})).toBe(true);
+      expect(isObject({ key: 'value' })).toBe(true);
+      expect(isObject({
+        numbers: {
+          int: 123,
+          decimal: 123.45,
+          bigInt: BigInt(123123123123123123),
+          bigNumb: new BigNumber(123123123123123123.12),
+          number: 123,
+        },
+        string: 'sample',
+        symbol: Symbol('sym'),
+        bool: true,
+        null: null,
+        undefined: undefined,
+      })).toBe(true);
+    });
+
+    test('should return true for null-prototype objects', () => {
+      const obj = Object.assign(Object.create(null), { abc: 123 });
+      expect(isObject(obj)).toBe(true);
+    });
+
+    it('should return false for arrays', () => {
+      expect(isObject([])).toBe(false);
+      expect(isObject([1, 2, 3])).toBe(false);
+    });
+
+    it('should return false for primitives', () => {
+      expect(isObject(123)).toBe(false);
+      expect(isObject('string')).toBe(false);
+      expect(isObject(true)).toBe(false);
+      expect(isObject(BigInt(123))).toBe(false);
+      expect(isObject(Symbol('sym'))).toBe(false);
+      expect(isObject(null)).toBe(false);
+      expect(isObject(undefined)).toBe(false);
+    });
+
+    it('should return false for functions', () => {
+      expect(isObject(function() {})).toBe(false);
+      expect(isObject(() => {})).toBe(false);
+    });
+
+    it('should return false for instances of custom classes', () => {
+      class Custom {}
+      expect(isObject(new Custom())).toBe(false);
     });
   });
 });

--- a/typescript-react/yarn.lock
+++ b/typescript-react/yarn.lock
@@ -8424,6 +8424,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"


### PR DESCRIPTION
Bumped `is-plain-object` because we started using `json-bigint` and it was required for `FunctionalUtils.isObject` to work as expected.