### PR TITLE
Add hover tooltip for quick search limitations

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.20"
+  "version": "1.9.21"
 }

--- a/typescript-react/src/components/View/FastFilter.tsx
+++ b/typescript-react/src/components/View/FastFilter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Input as InputField } from '../Input/Input';
+import { TooltipOnHover } from '../Tooltip/Tooltip';
 
 import styles from './Grid.module.css';
 
@@ -13,23 +14,30 @@ export class FastFilter extends React.PureComponent<IFastFilter> {
   public render() {
     return (
       <section className={styles.Search}>
-        <InputField
-          containerClassName={styles.InputContainer}
-          input={{
-            name: 'fast-search',
-            // TODO: remove this as any after redux-form typings get fixed
-            // any is here since onChange can receive either a value or a change event
-            // until we move to newer react (and better typings for redux-form with that) we are stuck with as any
-            onChange: this.onChange as any,
-            value: this.props.query || '',
-          } as any}
-          id='fast-search'
-          type='search'
-          // TODO: @bigd -> when inputs get hit with a refact-o-hammer this 'as any's can be dropped
-          meta={{} as any}
-          hideLabel
-          {...{ placeholder: 'Search...', 'data-qa-element-id': 'fast-search' }}
-        />
+        <TooltipOnHover
+          message='Search results include only items currently loaded (visible on the page).'
+          type='info'
+        >
+          <InputField
+            containerClassName={styles.InputContainer}
+            input={
+              {
+                name: 'fast-search',
+                // TODO: remove this as any after redux-form typings get fixed
+                // any is here since onChange can receive either a value or a change event
+                // until we move to newer react (and better typings for redux-form with that) we are stuck with as any
+                onChange: this.onChange as any,
+                value: this.props.query || '',
+              } as any
+            }
+            id='fast-search'
+            type='search'
+            // TODO: @bigd -> when inputs get hit with a refact-o-hammer this 'as any's can be dropped
+            meta={{} as any}
+            hideLabel
+            {...{ placeholder: 'Search...', 'data-qa-element-id': 'fast-search' }}
+          />
+        </TooltipOnHover>
       </section>
     );
   }


### PR DESCRIPTION
Adds a hover tooltip to Quick Search explaining
that results are limited to items currently
loaded on the page.

Data requiring additional fetching will not
appear in search results until it is loaded.