### PR TITLE
fix: preserve "." group separator in fromMachineFormat

### DIFF
--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -97,5 +97,5 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "source": "src/index.ts",
-  "version": "1.9.21"
+  "version": "1.9.22"
 }

--- a/typescript-react/src/util/Formatters/NumberFormatter.ts
+++ b/typescript-react/src/util/Formatters/NumberFormatter.ts
@@ -153,7 +153,14 @@ export const fromMachineFormat = (numberString: number | string, pattern: string
   const hasDecimalSeparator = format.decimalSeparator != null && format.decimalSeparator !== '';
 
   if (format.precision === 0 && !hasDecimalSeparator && numberString != null) {
-    return String(numberString).replace(/\.0+$/g, '');
+    const str = String(numberString);
+    const groupSize = format.groupSize ?? 0;
+
+    if (format.groupSeparator === '.' && groupSize > 1) {
+      return str.replace(new RegExp(`\\.0{1,${groupSize - 1}}$`), '');
+    }
+
+    return str.replace(/\.0+$/g, '');
   }
 
   return String(numberString);

--- a/typescript-react/src/util/Formatters/__tests__/NumberFormatter.spec.ts
+++ b/typescript-react/src/util/Formatters/__tests__/NumberFormatter.spec.ts
@@ -10,16 +10,41 @@ describe('NumberFormatter', () => {
 
       expect(parseNumberIncludingMachineFormat(100.00, format)).toBe('100');
       expect(parseNumberIncludingMachineFormat('200.00', format)).toBe('200');
+      expect(parseNumberIncludingMachineFormat('0.00', format)).toBe('0');
       expect(parseNumberIncludingMachineFormat('200.5', format)).toBe('200.5');
       expect(parseNumberIncludingMachineFormat('200.51', format)).toBe('200.51');
+      expect(parseNumberIncludingMachineFormat('0.5', format)).toBe('0.5');
       expect(parseNumberIncludingMachineFormat('300', format)).toBe('300');
       expect(parseNumberIncludingMachineFormat('1,000', format)).toBe('1000');
+      expect(parseNumberIncludingMachineFormat('1,234.56', format)).toBe('1234.56');
+      expect(parseNumberIncludingMachineFormat('1,234,567.89', format)).toBe('1234567.89');
+      expect(parseNumberIncludingMachineFormat('-1,000.50', format)).toBe('-1000.5');
+      expect(parseNumberIncludingMachineFormat('.5', format)).toBe('0.5');
+      expect(parseNumberIncludingMachineFormat('10.', format)).toBe('10');
 
       const nonDecimalFormat = '#,##0';
 
       expect(parseNumberIncludingMachineFormat(100, nonDecimalFormat)).toBe('100');
+      expect(parseNumberIncludingMachineFormat('0', nonDecimalFormat)).toBe('0');
       expect(parseNumberIncludingMachineFormat('100', nonDecimalFormat)).toBe('100');
+      expect(parseNumberIncludingMachineFormat('1234', nonDecimalFormat)).toBe('1234');
       expect(parseNumberIncludingMachineFormat('1,000', nonDecimalFormat)).toBe('1000');
+      expect(parseNumberIncludingMachineFormat('1,234,567', nonDecimalFormat)).toBe('1234567');
+      expect(parseNumberIncludingMachineFormat('-1,000', nonDecimalFormat)).toBe('-1000');
+    });
+
+    it('should return NaN for values that cannot be parsed', () => {
+      const format = '#,##0.00';
+
+      expect(parseNumberIncludingMachineFormat('abc', format)).toBeNaN();
+      expect(parseNumberIncludingMachineFormat('12abc', format)).toBeNaN();
+      expect(parseNumberIncludingMachineFormat('1.234', format)).toBeNaN();
+    });
+
+    it('should return an empty string for empty input', () => {
+      const format = '#,##0.00';
+
+      expect(parseNumberIncludingMachineFormat('', format)).toBe('');
     });
 
     it('should parse machine formatted numbers even if they do not match the format and are equal to the whole number', () => {
@@ -27,7 +52,13 @@ describe('NumberFormatter', () => {
 
       expect(parseNumberIncludingMachineFormat(100.00, nonDecimalFormat)).toBe('100');
       expect(parseNumberIncludingMachineFormat('100.00', nonDecimalFormat)).toBe('100');
+      expect(parseNumberIncludingMachineFormat('0.00', nonDecimalFormat)).toBe('0');
+      expect(parseNumberIncludingMachineFormat('0.0', nonDecimalFormat)).toBe('0');
+      expect(parseNumberIncludingMachineFormat('12345.00', nonDecimalFormat)).toBe('12345');
+      expect(parseNumberIncludingMachineFormat('-100.00', nonDecimalFormat)).toBe('-100');
       expect(parseNumberIncludingMachineFormat('1,000.00', nonDecimalFormat)).toBe('1000');
+      expect(parseNumberIncludingMachineFormat('1,234,567.00', nonDecimalFormat)).toBe('1234567');
+      expect(parseNumberIncludingMachineFormat('1000.000', nonDecimalFormat)).toBe('1000');
     });
 
     it('should not mess with machine formatted numbers that are not \.0+ and they should just fail to be parsed', () => {
@@ -35,13 +66,50 @@ describe('NumberFormatter', () => {
 
       expect(parseNumberIncludingMachineFormat('100.5', nonDecimalFormat)).toBeNaN();
       expect(parseNumberIncludingMachineFormat('100.51', nonDecimalFormat)).toBeNaN();
+      expect(parseNumberIncludingMachineFormat('1.5', nonDecimalFormat)).toBeNaN();
+      expect(parseNumberIncludingMachineFormat('0.1', nonDecimalFormat)).toBeNaN();
+      expect(parseNumberIncludingMachineFormat('1,000.5', nonDecimalFormat)).toBeNaN();
     });
 
     it('should only trigger if the decimal separator is not there', () => {
       const format = '#.##0,00';
 
       expect(parseNumberIncludingMachineFormat('100,00', format)).toBe('100');
+      expect(parseNumberIncludingMachineFormat('0,00', format)).toBe('0');
       expect(parseNumberIncludingMachineFormat('100,51', format)).toBe('100.51');
+      expect(parseNumberIncludingMachineFormat('100,5', format)).toBe('100.5');
+      expect(parseNumberIncludingMachineFormat('1.234,00', format)).toBe('1234');
+      expect(parseNumberIncludingMachineFormat('1.234,56', format)).toBe('1234.56');
+      expect(parseNumberIncludingMachineFormat('-1.000,50', format)).toBe('-1000.5');
+    });
+
+    it('should keep grouping intact but still strip machine decimals when "." is the group separator', () => {
+      const format = '#.##0';
+
+      // ungrouped values stay intact
+      expect(parseNumberIncludingMachineFormat('1', format)).toBe('1');
+      expect(parseNumberIncludingMachineFormat('12', format)).toBe('12');
+      expect(parseNumberIncludingMachineFormat('123', format)).toBe('123');
+      expect(parseNumberIncludingMachineFormat('1234', format)).toBe('1234');
+      expect(parseNumberIncludingMachineFormat('12345', format)).toBe('12345');
+      expect(parseNumberIncludingMachineFormat('1000000', format)).toBe('1000000');
+      expect(parseNumberIncludingMachineFormat('0', format)).toBe('0');
+      // machine decimals are stripped
+      expect(parseNumberIncludingMachineFormat('1.0', format)).toBe('1');
+      expect(parseNumberIncludingMachineFormat('-1.0', format)).toBe('-1');
+      expect(parseNumberIncludingMachineFormat('1.00', format)).toBe('1');
+      expect(parseNumberIncludingMachineFormat('100.00', format)).toBe('100');
+      expect(parseNumberIncludingMachineFormat('1000000.00', format)).toBe('1000000');
+      // grouping is preserved
+      expect(parseNumberIncludingMachineFormat('1.000', format)).toBe('1000');
+      expect(parseNumberIncludingMachineFormat('10.000', format)).toBe('10000');
+      expect(parseNumberIncludingMachineFormat('100.000', format)).toBe('100000');
+      expect(parseNumberIncludingMachineFormat('999.999.999', format)).toBe('999999999');
+      expect(parseNumberIncludingMachineFormat('1.000.000', format)).toBe('1000000');
+      expect(parseNumberIncludingMachineFormat('12.345.678', format)).toBe('12345678');
+      expect(parseNumberIncludingMachineFormat('1.234.567.890', format)).toBe('1234567890');
+      expect(parseNumberIncludingMachineFormat('-1.000', format)).toBe('-1000');
+      expect(parseNumberIncludingMachineFormat('-1.000.000', format)).toBe('-1000000');
     });
   });
 
@@ -52,18 +120,28 @@ describe('NumberFormatter', () => {
       expect(formatNumberToDecimals(25.5, 1)).toBe('25.5');
       expect(formatNumberToDecimals(1000.5, 1)).toBe('1000.5');
       expect(formatNumberToDecimals('100', 0)).toBe('100');
+      expect(formatNumberToDecimals(0, 2)).toBe('0.00');
+      expect(formatNumberToDecimals(-5.5, 2)).toBe('-5.50');
+      expect(formatNumberToDecimals(1000000, 0)).toBe('1000000');
     });
 
     it('should round the numbers if they have too many decimals', () => {
       expect(formatNumberToDecimals('100.5', 0)).toBe('101');
       expect(formatNumberToDecimals('100.25', 1)).toBe('100.3');
       expect(formatNumberToDecimals('100.24', 1)).toBe('100.2');
+      expect(formatNumberToDecimals('1.5', 0)).toBe('2');
+      expect(formatNumberToDecimals(123.456, 2)).toBe('123.46');
+      expect(formatNumberToDecimals('0.001', 2)).toBe('0.00');
     });
 
     it('should append decimals when insufficient precision is provided', () => {
       expect(formatNumberToDecimals(100, 2)).toBe('100.00');
       expect(formatNumberToDecimals(1000, 2)).toBe('1000.00');
       expect(formatNumberToDecimals('10.55', 4)).toBe('10.5500');
+    });
+
+    it('should return NaN for values that are not numbers', () => {
+      expect(formatNumberToDecimals('abc', 2)).toBe('NaN');
     });
   });
 });


### PR DESCRIPTION
Stripping trailing zeros with /\.0+$/ wrongly removed grouped digits for "." separator locales, turning "1.000" into "1". Now only strip when the zero count is below the group size, and guard the optional `groupSize`.